### PR TITLE
Bug Fix while declaring a DAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ The libraries name is inspired from the arabic word تَوَازٍ which means p
 This library is still in development. Breaking changes are expected.
 
 A couple of features will be released soon:
+* an example of running a set of calculations with the DAG and without the DAG
+  * we can show that using tawazi is transparent and one just has to remove the decorators! Then everything is back to normal
 * support multiprocessing
 * simulation of the execution using a DAG stored ledger
 * support more python versions

--- a/tawazi/__init__.py
+++ b/tawazi/__init__.py
@@ -3,7 +3,7 @@ from .ops import op, to_dag
 from .errors import ErrorStrategy
 
 """
-parallel-dag is a package that allows parallel execution of a set of functions written in Python
+tawazi is a package that allows parallel execution of a set of functions written in Python
 isort:skip_file
 """
 __version__ = "0.1.2"

--- a/tawazi/dag.py
+++ b/tawazi/dag.py
@@ -98,6 +98,10 @@ class ExecNode:
     def __repr__(self) -> str:
         return f"{self.__class__.__name__} {self.id} ~ | <{hex(id(self))}>"
 
+        # a string that identifies the ExecNode.
+        # It is either the name of the identifying function or the identifying string id_
+        self.__name__ = self.exec_function.__name__ if not isinstance(id_, str) else id_
+
     @property
     def computed_dependencies(self) -> bool:
         return isinstance(self.depends_on, list)
@@ -167,6 +171,10 @@ class DAG:
         }
         self.node_dict: Dict[Hashable, ExecNode] = {
             exec_node.id: exec_node for exec_node in self.exec_nodes
+        }
+
+        self.node_dict_by_name: Dict[str, ExecNode] = {
+            exec_node.__name__: exec_node for exec_node in self.exec_nodes
         }
 
         # a sequence of execution to be applied in a for loop

--- a/tawazi/dag.py
+++ b/tawazi/dag.py
@@ -89,6 +89,7 @@ class ExecNode:
         # It is either the name of the identifying function or the identifying string id_
         self.__name__ = self.exec_function.__name__ if not isinstance(id_, str) else id_
 
+        # Attempt to automatically assign a good enough argument name
         if isinstance(argument_name, str) and argument_name != "":
             self.argument_name = argument_name
         else:

--- a/tawazi/dag.py
+++ b/tawazi/dag.py
@@ -78,12 +78,16 @@ class ExecNode:
              Defaults to False.
         """
 
-        self.id = id_  # TODO: look into the typing of the id_
+        self.id = id_
         self.exec_function = exec_function
         self.depends_on = depends_on if depends_on else []
         self.priority = priority
         self.is_sequential = is_sequential
         self.logger = logger
+
+        # a string that identifies the ExecNode.
+        # It is either the name of the identifying function or the identifying string id_
+        self.__name__ = self.exec_function.__name__ if not isinstance(id_, str) else id_
 
         if isinstance(argument_name, str) and argument_name != "":
             self.argument_name = argument_name
@@ -97,10 +101,6 @@ class ExecNode:
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__} {self.id} ~ | <{hex(id(self))}>"
-
-        # a string that identifies the ExecNode.
-        # It is either the name of the identifying function or the identifying string id_
-        self.__name__ = self.exec_function.__name__ if not isinstance(id_, str) else id_
 
     @property
     def computed_dependencies(self) -> bool:

--- a/tawazi/ops.py
+++ b/tawazi/ops.py
@@ -13,6 +13,7 @@ exec_nodes_lock = Lock()
 
 
 class PreComputedExecNode(ExecNode):
+    # todo must change this because two functions in the same DAG can use the same argument name for two constants!
     def __init__(self, argument_name: str, value: Any):
         super().__init__(
             id_=argument_name,
@@ -146,7 +147,7 @@ def op(
     """
     Decorate a function to make it an ExecNode. When the decorated function is called, you are actually calling
     an ExecNode. This way we can record the dependencies in order to build the actual DAG.
-    Check the example in the README for a guide to the usage.
+    Please check the example in the README for a guide to the usage.
     Args:
         func: a Callable that will be executed in the DAG
         priority: priority of the execution with respect to other ExecNodes
@@ -162,11 +163,6 @@ def op(
     """
 
     def my_custom_op(_func: Callable[..., Any]) -> "LazyExecNode":
-        # rep_exec_node = ReplaceExecNode(func, priority, argument_name, is_sequential)
-        # functools.update_wrapper(rep_exec_node, func)
-        #
-        # return rep_exec_node
-
         lazy_exec_node = LazyExecNode(_func, priority, argument_name, is_sequential)
         functools.update_wrapper(lazy_exec_node, _func)
         return lazy_exec_node
@@ -181,11 +177,12 @@ def op(
 
 def to_dag(declare_dag_function: Callable[..., Any]) -> Callable[..., Any]:
     """
-    Transform the declared ops into a DAG that can be executed.
-    The same DAG can be executed multiple times
+    Transform the declared ops into a DAG that can be executed by tawazi.
+    The same DAG can be executed multiple times.
     Note: to_dag is thread safe because it uses an internal lock.
         If you need to construct lots of DAGs in multiple threads,
         it is best to construct your dag once and then consume it as much as you like in multiple threads.
+    Please check the example in the README for a guide to the usage.
     Args:
         declare_dag_function: a function that contains the execution of the DAG.
         if the functions are decorated with @op decorator they can be executed in parallel.

--- a/tests/test_edge_cases_dag.py
+++ b/tests/test_edge_cases_dag.py
@@ -1,0 +1,24 @@
+from tawazi import op, to_dag
+
+
+def test_same_constant_name_in_two_exec_nodes():
+    @op
+    def a(cst: int):
+        print(cst)
+        return cst
+
+    @op
+    def b(a, cst: str):
+        print(a, cst)
+        return str(a) + cst
+
+    @to_dag
+    def my_dag():
+        var_a = a(1234)
+        var_b = b(var_a, "poulpe")
+
+    dag = my_dag()
+    exec_nodes = dag.execute()
+    assert len(exec_nodes) == 4
+    assert exec_nodes[a.id].result == 1234
+    assert exec_nodes[b.id].result == "1234poulpe"


### PR DESCRIPTION
while Declaring a DAG, two functions couldn't use the same argument as constants. For example:
```
@op
def a(cst: int):
   ...

@op
def b(cst: str):
  ...

@to_dag
def mydag():
  a_ = a(123)
  b_ = b("skoubidou")
```
The code code will run the DAG, but the function `a` would receive the `cst` passed to `b` which is a `str`

