### PR TITLE
Clean code for 0.3 release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
     hooks:
       - id: flake8
         exclude: tests
+        args: ["--autofix"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.971

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,6 @@ repos:
     hooks:
       - id: flake8
         exclude: tests
-        args: ["--autofix"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.971

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ if __name__ == "__main__":
 
   t0 = time()
   # executing the dag takes a single line of code
-  deps_describer().execute()
+  deps_describer()
   execution_time = time() - t0
   assert execution_time < 1.5
   print(f"Graph execution took {execution_time:.2f} seconds")
@@ -104,27 +104,23 @@ def c(a, arg_b):
 # optionally customize the DAG
 @to_dag(max_concurrency=2, behavior="strict")
 def deps_describer():
-  result_a = a()
-  result_b = b()
-  result_c = c(result_a, result_b)
+  res_a = a()
+  res_b = b()
+  res_c = c(res_a, res_b)
+  return res_a, res_b, res_c
 
 if __name__ == "__main__":
 
   t0 = time()
   # the dag instance is reusable.
   # This is recommended if you want to do the same computation multiple times
-  dag = deps_describer()
-  results_1 = dag.execute()
+  res_a, res_b, res_c = deps_describer()
   execution_time = time() - t0
   print(f"Graph execution took {execution_time:.2f} seconds")
+  assert res_a == "A"
+  assert res_b == "B"
+  assert res_c == "A + B = C"
 
-  # debugging the code using `dag.safe_execute()` is easier
-  # because the execution doesn't go through the Thread pool
-  results_2 = dag.safe_execute()
-
-  # you can look throught the results of each operation like this:
-  for my_op in [a, b, c]:
-    assert results_1[my_op.id].result == results_2[my_op.id].result
 
 ```
 

--- a/tawazi/__init__.py
+++ b/tawazi/__init__.py
@@ -1,5 +1,5 @@
 from .dag import DAG
-from .ops import op, _to_dag, to_dag
+from .ops import op, to_dag
 from .errors import ErrorStrategy
 from .config import Cfg
 
@@ -9,4 +9,4 @@ isort:skip_file
 """
 __version__ = "0.2.0"
 
-__all__ = ["DAG", "op", "_to_dag", "to_dag", "ErrorStrategy", "Cfg"]
+__all__ = ["DAG", "op", "to_dag", "ErrorStrategy", "Cfg"]

--- a/tawazi/consts.py
+++ b/tawazi/consts.py
@@ -1,0 +1,12 @@
+from typing import List, Optional, Tuple, Union
+
+IdentityHash = str
+Tag = Union[None, str, tuple]  # anything immutable
+
+ARG_NAME_TAG = "twz_tag"
+
+RESERVED_KWARGS = [ARG_NAME_TAG]
+ARG_NAME_SEP = ">>>"
+USE_SEP_START = "<<"
+USE_SEP_END = ">>"
+ReturnIDsType = Optional[Union[List[IdentityHash], Tuple[IdentityHash], IdentityHash]]

--- a/tawazi/dag.py
+++ b/tawazi/dag.py
@@ -9,7 +9,7 @@ from networkx import find_cycle
 from networkx.exception import NetworkXNoCycle, NetworkXUnfeasible
 
 from .errors import ErrorStrategy, TawaziBaseException
-from .node import ExecNode, IdentityHash, PreComputedExecNode, Tag
+from .node import ExecNode, IdentityHash, PreCompArgExecNode, Tag
 
 
 # TODO: find a .pre-commit hook that aligns properly the fstrings
@@ -512,7 +512,7 @@ class DAG:
         # no calculation ExecNode (non setup ExecNode) should run... otherwise there is an error in implementation
         # NOTE: do not copy the setup nodes because we want them to be modified per DAG instance!
         all_setup_nodes = {
-            nd.id: nd for nd in self.exec_nodes if nd.setup or isinstance(nd, PreComputedExecNode)
+            nd.id: nd for nd in self.exec_nodes if nd.setup or isinstance(nd, PreCompArgExecNode)
         }
 
         # all the graph's leaves ids or the leave ids of the provided nodes

--- a/tawazi/dag.py
+++ b/tawazi/dag.py
@@ -9,7 +9,7 @@ from networkx import find_cycle
 from networkx.exception import NetworkXNoCycle, NetworkXUnfeasible
 
 from .errors import ErrorStrategy, TawaziBaseException
-from .node import ExecNode, IdentityHash, PreCompArgExecNode, Tag
+from .node import ArgExecNode, ExecNode, IdentityHash, Tag
 
 
 # TODO: find a .pre-commit hook that aligns properly the fstrings
@@ -512,7 +512,9 @@ class DAG:
         # no calculation ExecNode (non setup ExecNode) should run... otherwise there is an error in implementation
         # NOTE: do not copy the setup nodes because we want them to be modified per DAG instance!
         all_setup_nodes = {
-            nd.id: nd for nd in self.exec_nodes if nd.setup or isinstance(nd, PreCompArgExecNode)
+            nd.id: nd
+            for nd in self.exec_nodes
+            if nd.setup or (isinstance(nd, ArgExecNode) and nd.executed)
         }
 
         # all the graph's leaves ids or the leave ids of the provided nodes

--- a/tawazi/dag.py
+++ b/tawazi/dag.py
@@ -195,6 +195,8 @@ class DAG:
 
         # ExecNodes can be shared between Graphs, their call signatures might also be different
         self.exec_nodes = deepcopy(exec_nodes)
+        # TODO: is this necessary ?? I don't think so because we already deepcopy every LazyExecNode call
+        #  However we don't deep copy the arguments and the kwargs, so maybe just deepcopy the Args and and pass them
 
         self.max_concurrency = int(max_concurrency)
         assert max_concurrency >= 1, "Invalid maximum number of threads! Must be a positive integer"

--- a/tawazi/dag.py
+++ b/tawazi/dag.py
@@ -197,9 +197,7 @@ class DAG:
         self.graph_ids = DiGraphEx()
 
         # ExecNodes can be shared between Graphs, their call signatures might also be different
-        self.exec_nodes = deepcopy(exec_nodes)
-        # TODO: is this necessary ?? I don't think so because we already deepcopy every LazyExecNode call
-        #  However we don't deep copy the arguments and the kwargs, so maybe just deepcopy the Args and and pass them
+        self.exec_nodes = exec_nodes
 
         self.max_concurrency = int(max_concurrency)
         assert max_concurrency >= 1, "Invalid maximum number of threads! Must be a positive integer"

--- a/tawazi/dag.py
+++ b/tawazi/dag.py
@@ -11,6 +11,8 @@ from networkx.exception import NetworkXNoCycle, NetworkXUnfeasible
 from .errors import ErrorStrategy, TawaziBaseException
 from .node import ArgExecNode, ExecNode, IdentityHash, Tag
 
+ReturnIDsType = Optional[Union[List[IdentityHash], Tuple[IdentityHash], IdentityHash]]
+
 
 # TODO: find a .pre-commit hook that aligns properly the fstrings
 #   if it doesn't exist... make one! it should take max columns as argument
@@ -217,7 +219,7 @@ class DAG:
         self.node_dict_by_name: Dict[str, ExecNode] = {
             exec_node.__name__: exec_node for exec_node in self.exec_nodes
         }
-        self.return_ids: Optional[Union[List[IdentityHash], IdentityHash]] = None
+        self.return_ids: ReturnIDsType = None
         self.input_ids: Optional[List[IdentityHash]] = None
 
         # a sequence of execution to be applied in a for loop
@@ -572,6 +574,8 @@ class DAG:
         elif isinstance(self.return_ids, IdentityHash):
             # in this case it is returned_value
             returned_values = all_node_dicts[self.return_ids].result
+        elif isinstance(self.return_ids, tuple):
+            returned_values = tuple(all_node_dicts[ren_id].result for ren_id in self.return_ids)
         elif isinstance(self.return_ids, list):
             # TODO: for bla is instance
             returned_values = [all_node_dicts[ren_id].result for ren_id in self.return_ids]

--- a/tawazi/dag.py
+++ b/tawazi/dag.py
@@ -8,10 +8,11 @@ from loguru import logger
 from networkx import find_cycle
 from networkx.exception import NetworkXNoCycle, NetworkXUnfeasible
 
-from .errors import ErrorStrategy, TawaziBaseException
-from .node import ArgExecNode, ExecNode, IdentityHash, Tag
+from tawazi.consts import ReturnIDsType
 
-ReturnIDsType = Optional[Union[List[IdentityHash], Tuple[IdentityHash], IdentityHash]]
+from .consts import IdentityHash, Tag
+from .errors import ErrorStrategy, TawaziBaseException
+from .node import ArgExecNode, ExecNode
 
 
 # TODO: find a .pre-commit hook that aligns properly the fstrings
@@ -601,6 +602,8 @@ class DAG:
             node_dict[node_id].execute(node_dict)
 
         return node_dict
+
+    # TODO: get node by usage
 
     def handle_exception(self, graph: DiGraphEx, fut: "Future[Any]", id_: IdentityHash) -> None:
         """

--- a/tawazi/errors.py
+++ b/tawazi/errors.py
@@ -15,6 +15,10 @@ class TawaziArgumentException(TawaziBaseException):
         super().__init__(msg)
 
 
+class TawaziTypeError(TawaziBaseException):
+    pass
+
+
 def raise_arg_exc(func: Callable[[Any], Any], arg_name: str) -> None:
     raise TawaziArgumentException(func, arg_name)
 

--- a/tawazi/errors.py
+++ b/tawazi/errors.py
@@ -23,7 +23,7 @@ def raise_arg_exc(func: Callable[[Any], Any], arg_name: str) -> None:
     raise TawaziArgumentException(func, arg_name)
 
 
-class UnvalidExecNodeCall(TawaziBaseException):
+class InvalidExecNodeCall(TawaziBaseException):
     pass
 
 

--- a/tawazi/errors.py
+++ b/tawazi/errors.py
@@ -1,8 +1,22 @@
 from enum import Enum, unique
+from typing import Any, Callable
 
 
 class TawaziBaseException(BaseException):
     pass
+
+
+class TawaziArgumentException(TawaziBaseException):
+    def __init__(self, func: Callable[[Any], Any], arg_name: str) -> None:
+        msg = (
+            f"Argument {arg_name} wasn't passed for the DAG"
+            f" created from function {func.__qualname__}"
+        )
+        super().__init__(msg)
+
+
+def raise_arg_exc(func: Callable[[Any], Any], arg_name: str) -> None:
+    raise TawaziArgumentException(func, arg_name)
 
 
 class UnvalidExecNodeCall(TawaziBaseException):

--- a/tawazi/helpers.py
+++ b/tawazi/helpers.py
@@ -1,6 +1,8 @@
 import inspect
 from typing import Any, Callable, Dict, List, Tuple
 
+from tawazi.consts import USE_SEP_END, USE_SEP_START, IdentityHash
+
 
 def ordinal(numb: int) -> str:
     """Construct the string corresponding to the ordinal of a number
@@ -62,3 +64,10 @@ def get_args_and_default_args(func: Callable[..., Any]) -> Tuple[List[str], Dict
             args.append(k)
 
     return args, default_args
+
+
+def lazy_xn_id(base_id: IdentityHash, count_usages: int) -> IdentityHash:
+    if count_usages > 0:
+        return f"{base_id}{USE_SEP_START}{count_usages}{USE_SEP_END}"
+
+    return base_id

--- a/tawazi/helpers.py
+++ b/tawazi/helpers.py
@@ -1,0 +1,64 @@
+import inspect
+from typing import Any, Callable, Dict, List, Tuple
+
+
+def ordinal(numb: int) -> str:
+    """Construct the string corresponding to the ordinal of a number
+
+    Args:
+        numb (int): order
+
+    Returns:
+        str: "0th", "1st", "2nd", etc...
+    """
+    if numb < 20:  # determining suffix for < 20
+        if numb == 1:
+            suffix = "st"
+        elif numb == 2:
+            suffix = "nd"
+        elif numb == 3:
+            suffix = "rd"
+        else:
+            suffix = "th"
+    else:  # determining suffix for > 20
+        tens = str(numb)
+        tens = tens[-2]
+        unit = str(numb)
+        unit = unit[-1]
+        if tens == "1":
+            suffix = "th"
+        else:
+            if unit == "1":
+                suffix = "st"
+            elif unit == "2":
+                suffix = "nd"
+            elif unit == "3":
+                suffix = "rd"
+            else:
+                suffix = "th"
+    return str(numb) + suffix
+
+
+def get_args_and_default_args(func: Callable[..., Any]) -> Tuple[List[str], Dict[str, Any]]:
+    """
+    Retrieves the arguments names and the default arguments of a function.
+    Args:
+        func: the target function
+
+    Returns:
+        A Tuple containing a List of argument names of non default arguments,
+         and the mapping between the arguments and their default value for default arguments
+    >>> def f(a1, a2, *args, d1=123, d2=None): pass
+    >>> get_args_and_default_args(f)
+    >>> (['a1', 'a2', 'args'], {'d1': 123, 'd2': None})
+    """
+    signature = inspect.signature(func)
+    args = []
+    default_args = {}
+    for k, v in signature.parameters.items():
+        if v.default is not inspect.Parameter.empty:
+            default_args[k] = v.default
+        else:
+            args.append(k)
+
+    return args, default_args

--- a/tawazi/node.py
+++ b/tawazi/node.py
@@ -309,6 +309,7 @@ class LazyExecNode(ExecNode):
         Returns:
 
         """
+        # if LazyExecNode is not an attribute of a class, then return self
         if instance is None:
             # this is the case when we call the method on the class instead of an instance of the class
             # In this case, we must return a "function" hence an instance of this class

--- a/tawazi/node.py
+++ b/tawazi/node.py
@@ -32,8 +32,6 @@ class ExecNode:
     This class is the base executable node of the Directed Acyclic Execution Graph
     """
 
-    # todo deprecate calling the init directly!
-    # TODO: remove the default values from the parameters!
     def __init__(
         self,
         id_: IdentityHash,
@@ -64,7 +62,7 @@ class ExecNode:
         self.exec_function = exec_function
         self.priority = priority
         self.is_sequential = is_sequential
-        self.debug = debug
+        self.debug = debug  # TODO: do the fix to run debug nodes if their inputs exist
         self.tag = tag
         self.setup = setup
 

--- a/tawazi/node.py
+++ b/tawazi/node.py
@@ -109,7 +109,7 @@ class ExecNode:
         # 4. Assign a default NoVal to the result of the execution of this ExecNode,
         #  when this ExecNode will be executed, self.result will be overridden
         # It would be amazing if we can remove self.result and make ExecNode immutable
-        self.result: Union[NoValType, Dict[str, Any]] = NoVal
+        self.result: Union[NoValType, Any] = NoVal
         # even though setting result to NoVal is not necessary... it clarifies debugging
 
         # self.executed can be removed...

--- a/tawazi/node.py
+++ b/tawazi/node.py
@@ -20,6 +20,7 @@ Tag = Union[str, tuple]  # anything immutable
 ARG_NAME_TAG = "twz_tag"
 
 RESERVED_KWARGS = [ARG_NAME_TAG]
+ARG_NAME_SEP = ">>>"
 
 
 # TODO: make a helpers module and put this function in it
@@ -56,12 +57,16 @@ def ordinal(numb: int) -> str:
 # TODO: change the name!!
 def get_args_and_default_args(func: Callable[..., Any]) -> Tuple[List[str], Dict[str, Any]]:
     """
-    retrieves the default arguments of a function
+    Retrieves the arguments names and the default arguments of a function.
     Args:
-        func: the function with unknown defaults
+        func: the target function
 
     Returns:
-        the mapping between the arguments and their default value
+        A Tuple containing a List of argument names of non default arguments,
+         and the mapping between the arguments and their default value for default arguments
+    >>> def f(a1, a2, *args, d1=123, d2=None): pass
+    >>> get_args_and_default_args(f)
+    >>> (['a1', 'a2', 'args'], {'d1': 123, 'd2': None})
     """
     signature = inspect.signature(func)
     args = []
@@ -263,7 +268,9 @@ class LazyExecNode(ExecNode):
             if not isinstance(arg, ExecNode):
                 # NOTE: maybe use the name of the argument instead ?
                 arg = PreComputedExecNode(
-                    f"{self_copy.id} >>> {ordinal(i)} argument", self_copy.exec_function, arg
+                    f"{self_copy.id}{ARG_NAME_SEP}{ordinal(i)} argument",
+                    self_copy.exec_function,
+                    arg,
                 )
                 # Create a new ExecNode
                 exec_nodes.append(arg)
@@ -277,7 +284,7 @@ class LazyExecNode(ExecNode):
             # encapsulate the argument in PreComputedExecNode
             if not isinstance(arg, ExecNode):
                 arg = PreComputedExecNode(
-                    f"{self_copy.id} >>> {arg_name}", self_copy.exec_function, arg
+                    f"{self_copy.id}{ARG_NAME_SEP}{arg_name}", self_copy.exec_function, arg
                 )
                 # Create a new ExecNode
                 exec_nodes.append(arg)

--- a/tawazi/node.py
+++ b/tawazi/node.py
@@ -1,12 +1,12 @@
-import inspect
 from copy import deepcopy
 from threading import Lock
 from types import MethodType
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from loguru import logger
 
 from tawazi.errors import TawaziBaseException, UnvalidExecNodeCall, raise_arg_exc
+from tawazi.helpers import ordinal
 
 from .config import Cfg
 
@@ -25,63 +25,6 @@ ARG_NAME_SEP = ">>>"
 
 class NoVal:
     ...
-
-
-# TODO: make a helpers module and put this function in it
-def ordinal(numb: int) -> str:
-    if numb < 20:  # determining suffix for < 20
-        if numb == 1:
-            suffix = "st"
-        elif numb == 2:
-            suffix = "nd"
-        elif numb == 3:
-            suffix = "rd"
-        else:
-            suffix = "th"
-    else:  # determining suffix for > 20
-        tens = str(numb)
-        tens = tens[-2]
-        unit = str(numb)
-        unit = unit[-1]
-        if tens == "1":
-            suffix = "th"
-        else:
-            if unit == "1":
-                suffix = "st"
-            elif unit == "2":
-                suffix = "nd"
-            elif unit == "3":
-                suffix = "rd"
-            else:
-                suffix = "th"
-    return str(numb) + suffix
-
-
-# TODO: transfer to a helpers file
-# TODO: change the name!!
-def get_args_and_default_args(func: Callable[..., Any]) -> Tuple[List[str], Dict[str, Any]]:
-    """
-    Retrieves the arguments names and the default arguments of a function.
-    Args:
-        func: the target function
-
-    Returns:
-        A Tuple containing a List of argument names of non default arguments,
-         and the mapping between the arguments and their default value for default arguments
-    >>> def f(a1, a2, *args, d1=123, d2=None): pass
-    >>> get_args_and_default_args(f)
-    >>> (['a1', 'a2', 'args'], {'d1': 123, 'd2': None})
-    """
-    signature = inspect.signature(func)
-    args = []
-    default_args = {}
-    for k, v in signature.parameters.items():
-        if v.default is not inspect.Parameter.empty:
-            default_args[k] = v.default
-        else:
-            args.append(k)
-
-    return args, default_args
 
 
 class ExecNode:
@@ -276,8 +219,6 @@ class LazyExecNode(ExecNode):
             setup=setup,
         )
 
-    # TODO: support tagging an ExecNode using __tawazi_call_tag or smthing like that
-    #  maybe something like twz_tag might be acceptable ?
     def __call__(self, *args: Any, **kwargs: Any) -> "LazyExecNode":
         """
         Record the dependencies in a global variable to be called later in DAG.

--- a/tawazi/ops.py
+++ b/tawazi/ops.py
@@ -51,54 +51,6 @@ def op(
         return my_custom_op(func)
 
 
-# TODO: delete!!!
-# NOTE: deprecated!!
-def _to_dag(
-    declare_dag_function: Optional[Callable[..., Any]] = None,
-    *,
-    max_concurrency: int = 1,
-    behavior: ErrorStrategy = ErrorStrategy.strict,
-) -> Callable[..., DAG]:
-    """
-    deprecated!! use to_pipe instead
-    Transform the declared ops into a DAG that can be executed by tawazi.
-    The same DAG can be executed multiple times.
-    Note: to_dag is thread safe because it uses an internal lock.
-        If you need to construct lots of DAGs in multiple threads,
-        it is best to construct your dag once and then consume it as much as you like in multiple threads.
-    Please check the example in the README for a guide to the usage.
-    Args:
-        declare_dag_function: a function that contains the execution of the DAG.
-        if the functions are decorated with @op decorator they can be executed in parallel.
-        Otherwise, they will be executed immediately. Currently mixing the two behaviors isn't supported.
-        max_concurrency: the maximum number of concurrent threads to execute in parallel
-        behavior: the behavior of the dag when an error occurs during the execution of a function (ExecNode)
-    Returns: a DAG instance
-
-    """
-
-    def intermediate_wrapper(_func: Callable[..., Any]) -> Callable[..., DAG]:
-        def wrapped(*args: Any, **kwargs: Any) -> DAG:
-            # TODO: modify this horrible pattern
-            with exec_nodes_lock:
-                node.exec_nodes = []
-                _func(*args, **kwargs)
-                d = DAG(node.exec_nodes, max_concurrency=max_concurrency, behavior=behavior)
-                node.exec_nodes = []
-
-            return d
-
-        return wrapped
-
-    # case 1: arguments are provided to the decorator
-    if declare_dag_function is None:
-        # return a decorator
-        return intermediate_wrapper  # type: ignore
-    # case 2: arguments aren't provided to the decorator
-    else:
-        return intermediate_wrapper(declare_dag_function)
-
-
 def to_dag(
     declare_dag_function: Optional[Callable[..., Any]] = None,
     *,

--- a/tawazi/ops.py
+++ b/tawazi/ops.py
@@ -73,34 +73,51 @@ def to_dag(
     Returns: a DAG instance
     """
 
+    # wrapper used to support parametrized and non parametrized decorators
     def intermediate_wrapper(_func: Callable[..., Any]) -> DAG:
+
         # 0. Protect against multiple threads declaring many DAGs at the same time
         with exec_nodes_lock:
+
             # 1. node.exec_nodes contains all the ExecNodes that concern the DAG being built at the moment.
             #      make sure it is empty
             node.exec_nodes = []
 
             # 2. make ExecNodes corresponding to the arguments of the ExecNode
+            # 2.1 get the names of the arguments and the default values
             func_args, func_default_args = get_args_and_default_args(_func)
-            # non default parameters must be provided!
-            args: List[ExecNode] = [ArgExecNode(_func, arg_name) for arg_name in func_args]
 
+            # 2.2 Construct non default arguments.
+            # Corresponding values must be provided during usage
+            args: List[ExecNode] = [ArgExecNode(_func, arg_name) for arg_name in func_args]
+            # 2.2 Construct Default arguments.
             args.extend(
                 [ArgExecNode(_func, arg_name, arg) for arg_name, arg in func_default_args.items()]
             )
+            # 2.3 Arguments are also ExecNodes that get executed inside the scheduler
             node.exec_nodes.extend(args)
 
-            # Only ordered parameters are supported at the moment
+            # 3. Execute the dependency describer function
+            # NOTE: Only ordered parameters are supported at the moment!
+            #  No **kwargs!! Only positional Arguments
             returned_exec_nodes = _func(*args)
 
+            # 4. Construct the DAG instance
             d = DAG(node.exec_nodes, max_concurrency=max_concurrency, behavior=behavior)
+
+            # 5. Clean global variable
             # node.exec_nodes are deep copied inside the DAG.
             #   we can emtpy the global variable node.exec_nodes
+            # TODO: clean node.exec_nodes even if an error is raised put it in finally block
             node.exec_nodes = []
 
             d.input_ids = [arg.id for arg in args]
 
-            # make the return ids to be fetched at the end of the computation
+            # 6. make the return ids to be fetched at the end of the computation
+            # TODO: support List and Dicts
+            err = TypeError(
+                "Return type of the pipeline must be either a Single value, Tuple of Values or Nothing"
+            )
             return_ids: Optional[Union[List[IdentityHash], IdentityHash]] = []
             if returned_exec_nodes is None:
                 return_ids = None
@@ -114,13 +131,9 @@ def to_dag(
                     else:
                         # NOTE: this error shouldn't ever raise during usage.
                         # Please report in https://github.com/mindee/tawazi/issues
-                        raise TypeError(
-                            "Return type of the pipeline must be either an execNode or a tuple of ExecNode"
-                        )
+                        raise err
             else:
-                raise TypeError(
-                    "Return type of the pipeline must be either an execNode or a tuple of ExecNode"
-                )
+                raise err
 
             d.return_ids = return_ids
 

--- a/tawazi/ops.py
+++ b/tawazi/ops.py
@@ -3,17 +3,11 @@ from typing import Any, Callable, List, Optional, Union
 
 from tawazi import DAG
 from tawazi.errors import ErrorStrategy
+from tawazi.helpers import get_args_and_default_args
 
 from . import node
 from .config import Cfg
-from .node import (
-    ArgExecNode,
-    ExecNode,
-    IdentityHash,
-    LazyExecNode,
-    exec_nodes_lock,
-    get_args_and_default_args,
-)
+from .node import ArgExecNode, ExecNode, IdentityHash, LazyExecNode, exec_nodes_lock
 
 
 # TODO: modify is_sequential's default value according to the pre used default

--- a/tawazi/ops.py
+++ b/tawazi/ops.py
@@ -11,7 +11,6 @@ from .node import (
     ExecNode,
     IdentityHash,
     LazyExecNode,
-    PreCompArgExecNode,
     exec_nodes_lock,
     get_args_and_default_args,
 )
@@ -142,7 +141,7 @@ def to_dag(
 
         args.extend(
             [
-                PreCompArgExecNode(declare_dag_function, arg_name, arg)
+                ArgExecNode(declare_dag_function, arg_name, arg)
                 for arg_name, arg in func_default_args.items()
             ]
         )

--- a/tawazi/ops.py
+++ b/tawazi/ops.py
@@ -1,16 +1,16 @@
 import functools
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Callable, List, Optional
 
 from tawazi import DAG
-from tawazi.errors import ErrorStrategy
+from tawazi.dag import ReturnIDsType
+from tawazi.errors import ErrorStrategy, TawaziTypeError
 from tawazi.helpers import get_args_and_default_args
 
 from . import node
 from .config import Cfg
-from .node import ArgExecNode, ExecNode, IdentityHash, LazyExecNode, exec_nodes_lock
+from .node import ArgExecNode, ExecNode, LazyExecNode, exec_nodes_lock
 
 
-# TODO: modify is_sequential's default value according to the pre used default
 def op(
     func: Optional[Callable[..., Any]] = None,
     *,
@@ -21,22 +21,30 @@ def op(
     setup: bool = False,
 ) -> LazyExecNode:
     """
-    Decorate a function to make it an ExecNode. When the decorated function is called, you are actually calling
-    an ExecNode. This way we can record the dependencies in order to build the actual DAG.
+    Decorate a function to make it an ExecNode.
+    When the decorated function is called, you are actually calling an ExecNode.
+    This way we can record the dependencies in order to build the actual DAG.
     Please check the example in the README for a guide to the usage.
     Args:
-        func: a Callable that will be executed in the DAG
-        priority: priority of the execution with respect to other ExecNodes
-        is_sequential: whether to allow the execution of this ExecNode with others or not
-
+        func (Callable[..., Any]): a Callable that will be executed in the DAG
+        priority (int): priority of the execution with respect to other ExecNodes
+        is_sequential (bool): whether to allow the execution of this ExecNode with others or not
+        debug (bool): if True, this node will be executed when the corresponding DAG runs in Debug mode.
+          This means that this ExecNode will run if its inputs exists
+        tag (Any): Any Hashable / immutable typed variable can be used to identify nodes (str, Tuples, int etc.).
+           It is the responsibility of the user to provide this immutability of the tag.
+        setup (bool): if True, this node will be executed only once during the lifetime of a DAG instance.
+          Setup ExecNodes are meant to be used to load heavy data only once inside the execution pipeline and then be used as if the results were cached.
+          This can be useful if you want to load heavy ML models, heavy Data etc.
+          Note that you can run all / subset of the setup nodes by invoking the DAG.setup method
+          NOTE: setup nodes are currently not threadsafe!
+            because they are shared between all threads!
+            If you execute the same pipeline in multiple threads during the setup phase, the behavior is undefined.
+            This is why it is best to invoke the DAG.setup method before using the DAG in a multithreaded environment.
+            This problem will be resolved in the future
     Returns:
-        LazyExecNode
+        LazyExecNode: The decorated function wrapped in a Callable.
     """
-    # TODO: maybe setup nodes are not threadsafe!
-    #   because they are shared between all threads!
-    #   I mean shared per pipeline… so if you execute the same pipeline in multiple threads,
-    #   it is not thread safe!
-    # so we should execute it using a thread  safety of 1 !!
 
     def my_custom_op(_func: Callable[..., Any]) -> "LazyExecNode":
         lazy_exec_node = LazyExecNode(_func, priority, is_sequential, debug, tag, setup)
@@ -112,30 +120,39 @@ def to_dag(
             finally:
                 # 5. Clean global variable
                 # node.exec_nodes are deep copied inside the DAG.
-                #   we can epmty the global variable node.exec_nodes
+                #   we can empty the global variable node.exec_nodes
                 node.exec_nodes = []
 
             d.input_ids = [arg.id for arg in args]
 
             # 6. make the return ids to be fetched at the end of the computation
-            # TODO: support List and Dicts
-            err = TypeError(
+            # TODO: support Dicts and iterators etc.
+            err = TawaziTypeError(
                 "Return type of the pipeline must be either a Single value, Tuple of Values or Nothing"
             )
-            return_ids: Optional[Union[List[IdentityHash], IdentityHash]] = []
+            # 6.1 returned values can be of multiple nature
+            return_ids: ReturnIDsType = []
+            # 6.2 No value returned by the execution
             if returned_exec_nodes is None:
                 return_ids = None
+            # 6.3 a single value is returned
             elif isinstance(returned_exec_nodes, ExecNode):
                 return_ids = returned_exec_nodes.id
-            elif isinstance(returned_exec_nodes, tuple):
+            # 6.4 multiple values returned
+            elif isinstance(returned_exec_nodes, (tuple, list)):
+                # 6.4.1 Collect all the return ids
                 for ren in returned_exec_nodes:
                     if isinstance(ren, ExecNode):
-                        # NOTE: maybe consider dropping the Optional
                         return_ids.append(ren.id)  # type: ignore
                     else:
                         # NOTE: this error shouldn't ever raise during usage.
                         # Please report in https://github.com/mindee/tawazi/issues
                         raise err
+                # 6.4.2 Cast to the corresponding type
+                if isinstance(returned_exec_nodes, tuple):
+                    return_ids = tuple(return_ids)  # type: ignore
+                # 6.4.3 No Cast is necessary for the List because this is the default
+                # NOTE: this cast must be done when adding other types!
             else:
                 raise err
 

--- a/tawazi/ops.py
+++ b/tawazi/ops.py
@@ -2,12 +2,12 @@ import functools
 from typing import Any, Callable, List, Optional
 
 from tawazi import DAG
-from tawazi.dag import ReturnIDsType
 from tawazi.errors import ErrorStrategy, TawaziTypeError
 from tawazi.helpers import get_args_and_default_args
 
 from . import node
 from .config import Cfg
+from .consts import ReturnIDsType
 from .node import ArgExecNode, ExecNode, LazyExecNode, exec_nodes_lock
 
 

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -44,7 +44,7 @@ def test_strict_error_behavior():
     pytest.behavior_comp_str = ""
     g = DAG(list_execnodes, 1, behavior=ErrorStrategy.strict)
     try:
-        g.execute()
+        g._execute()
     except NotImplementedError:
         pass
 
@@ -52,14 +52,14 @@ def test_strict_error_behavior():
 def test_all_children_behavior():
     pytest.behavior_comp_str = ""
     g = DAG(list_execnodes, 1, behavior=ErrorStrategy.all_children)
-    g.execute()
+    g._execute()
     assert pytest.behavior_comp_str == "ad"
 
 
 def test_permissive_behavior():
     pytest.behavior_comp_str = ""
     g = DAG(list_execnodes, 1, behavior=ErrorStrategy.permissive)
-    g.execute()
+    g._execute()
     assert pytest.behavior_comp_str == "acd"
 
 

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -33,10 +33,10 @@ def d(a):
     pytest.behavior_comp_str += "d"
 
 
-en_a = ExecNode(a.__name__, a, priority=1, is_sequential=False)
-en_b = ExecNode(b.__name__, b, args=[en_a], priority=2, is_sequential=False)
-en_c = ExecNode(c.__name__, c, args=[en_b], priority=2, is_sequential=False)
-en_d = ExecNode(d.__name__, d, args=[en_a], priority=1, is_sequential=False)
+en_a = ExecNode(a.__qualname__, a, priority=1, is_sequential=False)
+en_b = ExecNode(b.__qualname__, b, args=[en_a], priority=2, is_sequential=False)
+en_c = ExecNode(c.__qualname__, c, args=[en_b], priority=2, is_sequential=False)
+en_d = ExecNode(d.__qualname__, d, args=[en_a], priority=1, is_sequential=False)
 list_execnodes = [en_a, en_b, en_c, en_d]
 
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -67,7 +67,7 @@ failing_execnodes = list_execnodes + [ExecNode(fail.__name__, fail, [en_g], is_s
 def test_dag_build():
     g = DAG(list_execnodes, 2, behavior=ErrorStrategy.strict)
     t0 = time()
-    g.execute()  # must never fail!
+    g._execute()  # must never fail!
     print(time() - t0)
     for k, v in g.node_dict.items():
         print(g, v, v.result)
@@ -82,6 +82,6 @@ def test_draw():
 def test_bad_behaviour():
     try:
         g = DAG(failing_execnodes, 2, behavior="Such Bad Behavior")
-        g.execute()
+        g._execute()
     except NotImplementedError:
         pass

--- a/tests/test_compound_priority.py
+++ b/tests/test_compound_priority.py
@@ -3,7 +3,7 @@ from time import sleep
 
 import pytest
 
-from tawazi import _to_dag, op
+from tawazi import op, to_dag
 
 """Internal Unit Test"""
 
@@ -41,7 +41,7 @@ def e():
     pytest.compound_priority_str += "e"
 
 
-@_to_dag
+@to_dag
 def dependency_describer():
     _a = a()
     _b = b(_a)
@@ -51,7 +51,7 @@ def dependency_describer():
 
 
 def test_compound_priority():
-    dag = dependency_describer()
+    dag = dependency_describer
 
     assert dag.node_dict_by_name["a"].compound_priority == 4
     assert dag.node_dict_by_name["b"].compound_priority == 2
@@ -62,8 +62,7 @@ def test_compound_priority():
 
 def test_compound_priority():
     pytest.compound_priority_str == ""
-    dag = dependency_describer()
-    dag.execute()
+    dependency_describer()
 
     assert pytest.compound_priority_str.startswith("ab")
     assert len(pytest.compound_priority_str) == 5

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,7 +1,7 @@
 # type: ignore
 from functools import wraps
 
-from tawazi import _to_dag, op
+from tawazi import op, to_dag
 
 """Integration test"""
 
@@ -29,12 +29,11 @@ def b(a):
     return "tata" + a
 
 
-@_to_dag
+@to_dag
 def pipe():
     a_ = a()
     t = b(a_)
 
 
 def test_decorator():
-    p = pipe()
-    p.execute()
+    pipe()

--- a/tests/test_edge_cases_dag.py
+++ b/tests/test_edge_cases_dag.py
@@ -1,5 +1,5 @@
 #  type: ignore
-from tawazi import _to_dag, op
+from tawazi import op, to_dag
 
 """integration test"""
 
@@ -15,13 +15,12 @@ def test_same_constant_name_in_two_exec_nodes():
         print(a, cst)
         return str(a) + cst
 
-    @_to_dag
+    @to_dag
     def my_dag():
         var_a = a(1234)
         var_b = b(var_a, "poulpe")
 
-    dag = my_dag()
-    exec_nodes = dag.execute()
+    exec_nodes = my_dag.execute()
     assert len(exec_nodes) == 4
     assert exec_nodes[a.id].result == 1234
     assert exec_nodes[b.id].result == "1234poulpe"

--- a/tests/test_edge_cases_dag.py
+++ b/tests/test_edge_cases_dag.py
@@ -20,7 +20,7 @@ def test_same_constant_name_in_two_exec_nodes():
         var_a = a(1234)
         var_b = b(var_a, "poulpe")
 
-    exec_nodes = my_dag.execute()
+    exec_nodes = my_dag._execute()
     assert len(exec_nodes) == 4
     assert exec_nodes[a.id].result == 1234
     assert exec_nodes[b.id].result == "1234poulpe"

--- a/tests/test_error_during_dag_build.py
+++ b/tests/test_error_during_dag_build.py
@@ -1,0 +1,19 @@
+# type: ignore
+import pytest
+
+from tawazi import node, op, to_dag
+
+
+def test_execnodes():
+    @op
+    def a():
+        pass
+
+    with pytest.raises(NameError):
+
+        @to_dag
+        def pipe():
+            a()
+            b()  # an undefined ExecNode
+
+    assert node.exec_nodes == []

--- a/tests/test_execution_time.py
+++ b/tests/test_execution_time.py
@@ -1,7 +1,7 @@
 # type: ignore
 from time import sleep, time
 
-from tawazi import _to_dag, op
+from tawazi import op, to_dag
 
 """integration test"""
 
@@ -23,7 +23,7 @@ def c(a, b):
     sleep(T)
 
 
-@_to_dag(max_concurrency=2)
+@to_dag(max_concurrency=2)
 def deps():
     a_ = a()
     b_ = b()
@@ -32,6 +32,6 @@ def deps():
 
 def test_timing():
     t0 = time()
-    deps().execute()
+    deps()
     execution_time = time() - t0
     assert execution_time < 2.5 * T

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -40,24 +40,25 @@ class MyClass:
         logger.debug("ran d")
         return "d"
 
-    @to_dag
-    def my_custom_dag(self):
-        vara = self.a()
-        varb = self.b(vara)
-        varc = self.c(vara)
-        _vard = self.d(varb, c=varc, fourth_argument=1111)
+
+#     @to_dag
+#     def my_custom_dag(self):
+#         vara = self.a()
+#         varb = self.b(vara)
+#         varc = self.c(vara)
+#         _vard = self.d(varb, c=varc, fourth_argument=1111)
 
 
-def test_ops_interface():
-    c = MyClass()
+# def test_ops_interface():
+#     c = MyClass()
 
-    d1 = c.my_custom_dag()
-    logger.debug("\n1st execution of dag")
-    d1.execute()
-    assert pytest.third_argument == 1234
-    assert pytest.fourth_argument == 1111
-    logger.debug("\n2nd execution of dag")
-    d1.execute()
+#     d1 = c.my_custom_dag()
+#     logger.debug("\n1st execution of dag")
+#     d1.execute()
+#     assert pytest.third_argument == 1234
+#     assert pytest.fourth_argument == 1111
+#     logger.debug("\n2nd execution of dag")
+#     d1.execute()
 
 
 """

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -4,7 +4,7 @@ from typing import Union
 
 import pytest
 
-from tawazi import _to_dag, op
+from tawazi import op, to_dag
 
 """integration test"""
 
@@ -40,7 +40,7 @@ class MyClass:
         logger.debug("ran d")
         return "d"
 
-    @_to_dag
+    @to_dag
     def my_custom_dag(self):
         vara = self.a()
         varb = self.b(vara)
@@ -58,3 +58,17 @@ def test_ops_interface():
     assert pytest.fourth_argument == 1111
     logger.debug("\n2nd execution of dag")
     d1.execute()
+
+
+"""
+The use case for this feature is the following:
+
+The user has a Class with an instance that contains a lof of methods and attributes.
+This class contains a very complicated function that can benefit from parallelization.
+The user wants to run the dag multiple times and get the same results...
+    he is responsible for the modifications that any function might do on the instance...
+    He should be warned about the parallelization dangers when dealing with shared data (in this case self!)
+The user (in the best case scenario) will only exchange mutable data between the methods via the parameters
+This will ensure the dependency of execution will be respected!
+"""
+# TODO: do some advanced tests on this case!

--- a/tests/test_multiple_return_value_for_graph.py
+++ b/tests/test_multiple_return_value_for_graph.py
@@ -1,0 +1,52 @@
+# type: ignore
+import pytest
+
+from tawazi import op, to_dag
+from tawazi.errors import TawaziTypeError
+
+
+@op
+def a(v):
+    return v
+
+
+def test_no_return():
+    @to_dag
+    def pipe():
+        return
+
+    assert pipe() == None
+
+
+def test_return_single():
+    @to_dag
+    def pipe():
+        return a("twinkle")
+
+    assert pipe() == "twinkle"
+
+
+def test_return_tuple():
+    @to_dag
+    def pipe():
+        res = a("tata")
+        return res, res, res
+
+    assert pipe() == ("tata", "tata", "tata")
+
+
+def test_return_list():
+    @to_dag
+    def pipe():
+        res = a("tata")
+        return [res, res, res]
+
+    assert pipe() == ["tata", "tata", "tata"]
+
+
+def test_return_invalid_type():
+    with pytest.raises(TawaziTypeError):
+
+        @to_dag
+        def pipe():
+            return "bhasdfkjals"

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -1,5 +1,8 @@
 # type: ignore
+import pytest
+
 from tawazi import op, to_dag
+from tawazi.errors import InvalidExecNodeCall
 
 """integration test"""
 
@@ -64,3 +67,8 @@ def pipe():
 
 def test_ops_signatures():
     pipe()
+
+
+def test_invalid_call_execnode():
+    with pytest.raises(InvalidExecNodeCall):
+        f6()

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -1,5 +1,5 @@
 # type: ignore
-from tawazi import _to_dag, op
+from tawazi import op, to_dag
 
 """integration test"""
 
@@ -48,7 +48,7 @@ def f8(f1, *args, **kwargs):
     return sum([f1, *args, *(kwargs.values())])
 
 
-@_to_dag
+@to_dag
 def pipe():
     _1 = f1()
     # import ipdb
@@ -63,5 +63,4 @@ def pipe():
 
 
 def test_ops_signatures():
-    p = pipe()
-    p.execute()
+    pipe()

--- a/tests/test_ops_interface.py
+++ b/tests/test_ops_interface.py
@@ -4,7 +4,7 @@ from typing import Union
 
 import pytest
 
-from tawazi import _to_dag, op
+from tawazi import op, to_dag
 
 """integration test"""
 
@@ -41,7 +41,7 @@ def test_ops_interface():
         # logger.debug(f"ran d {some_constant} {keyworded_arg}")
         return "d"
 
-    @_to_dag
+    @to_dag
     def my_custom_dag():
         vara = a()
         varb = b(vara)
@@ -62,7 +62,7 @@ def test_ops_interface():
         logger.debug(f"e is {e}")
         logger.debug("ran f")
 
-    @_to_dag
+    @to_dag
     def my_other_custom_dag():
         vara = a()
         varb = b(vara)
@@ -71,27 +71,25 @@ def test_ops_interface():
         vare = e()
         _varf = f(vara, varb, varc, vard, vare)
 
-    d1 = my_custom_dag()
     logger.debug("\n1st execution of dag")
-    d1.execute()
+    my_custom_dag()
     assert pytest.third_argument == 1234
     assert pytest.fourth_argument == 1111
     logger.debug("\n2nd execution of dag")
-    d1.execute()
+    my_custom_dag()
     assert pytest.third_argument == 1234
     assert pytest.fourth_argument == 1111
 
-    d2 = my_other_custom_dag()
     logger.debug("\n1st execution of other dag")
-    d2.execute()
+    my_other_custom_dag()
     assert pytest.third_argument == "blabla"
     assert pytest.fourth_argument == 2222
     logger.debug("\n2nd execution of other dag")
-    d2.execute()
+    my_other_custom_dag()
     assert pytest.third_argument == "blabla"
     assert pytest.fourth_argument == 2222
 
     logger.debug("\n3rd execution of dag")
-    d1.execute()
+    my_custom_dag()
     assert pytest.third_argument == 1234
     assert pytest.fourth_argument == 1111

--- a/tests/test_pipeline_input_output.py
+++ b/tests/test_pipeline_input_output.py
@@ -3,7 +3,7 @@
 import pytest
 
 from tawazi import op, to_dag
-from tawazi.errors import TawaziBaseException
+from tawazi.errors import TawaziArgumentException, TawaziBaseException
 
 
 @op
@@ -22,6 +22,11 @@ def declare_dag_function(input_img, cst: int = 0):
     return a(input_img, cst)
 
 
+@op
+def op1(in1):
+    return in1 + 1
+
+
 def test_pipeline_input_output():
     l = declare_dag_function([1, 2, 3], 10)
     assert l == 16
@@ -35,3 +40,21 @@ def test_pipeline_input_output_skipping_default_params():
 def test_pipeline_input_output_missing_argument():
     with pytest.raises(TawaziBaseException):
         l = declare_dag_function()
+
+
+def test_pipeline_default_args_input_not_provided():
+    @to_dag
+    def pipe(in1=1, in2=2, in3=3, in4=4):
+        return op1(in1), op1(in2), op1(in3), op1(in4)
+
+    assert pipe() == (2, 3, 4, 5)
+
+
+def test_pipeline_args_input_not_provided():
+    # should fail!!
+    @to_dag
+    def pipe(in1, in2, in3, in4):
+        return op1(in1), op1(in2), op1(in3), op1(in4)
+
+    with pytest.raises(TawaziArgumentException):
+        pipe()

--- a/tests/test_priority_sequential.py
+++ b/tests/test_priority_sequential.py
@@ -51,7 +51,7 @@ def test_priority():
         list_execnodes = [en_a, en_b, en_c, en_d]
 
         g = DAG(list_execnodes, 1, behavior=ErrorStrategy.strict)
-        g.execute()
+        g._execute()
         assert pytest.priority_sequential_comp_str == "abcd", f"during {_i}th iteration"
 
 
@@ -67,7 +67,7 @@ def test_sequentiality():
         list_execnodes = [en_a, en_b, en_c, en_d, en_e]
 
         g = DAG(list_execnodes, 2, behavior=ErrorStrategy.strict)
-        g.execute()
+        g._execute()
         ind_a = pytest.priority_sequential_comp_str.index("a")
         ind_b = pytest.priority_sequential_comp_str.index("b")
         ind_c = pytest.priority_sequential_comp_str.index("c")

--- a/tests/test_safe_execution.py
+++ b/tests/test_safe_execution.py
@@ -1,4 +1,5 @@
 #  type: ignore
+from copy import deepcopy
 from time import sleep
 
 import pytest
@@ -66,3 +67,62 @@ def test_safe_execution():
     pytest.safe_execution_val = ""
     dagger.safe_execute()
     assert pytest.safe_execution_val in ["ABC", "BAC"]
+
+
+@op
+def op1(in1):
+    return in1 + 1
+
+
+@op
+def op_cst(in1=1):
+    pytest.safe_execution_op_cst_has_run = True
+    return in1 + 2
+
+
+@op(setup=True)
+def setop(in1):
+    pytest.safe_execution_c += 1
+    return in1 + 3
+
+
+# TODO: this should raise a warning!! because passing in an argument to the setup nodes!!
+@to_dag
+def pipe(in1):
+    out_setop = setop(in1)
+    out1 = op1(out_setop)
+    return out1, op_cst()
+
+
+def test_normal_execution_with_setup():
+    pipe_ = deepcopy(pipe)
+    pytest.safe_execution_c = 0
+    assert pipe_(1) == (5, 3)
+    assert pytest.safe_execution_c == 1
+    assert pipe_(2) == (5, 3)
+    assert pytest.safe_execution_c == 1
+
+
+def test_safe_execution_with_setup():
+    pipe_ = deepcopy(pipe)
+    pytest.safe_execution_c = 0
+    assert pipe_.safe_execute(1) == (5, 3)
+    assert pytest.safe_execution_c == 1
+    assert pipe_.safe_execute(2) == (5, 3)
+    assert pytest.safe_execution_c == 1
+
+
+def test_subgraph_with_safe_execution_with_setup():
+    pipe_ = deepcopy(pipe)
+    pytest.safe_execution_c = 0
+    pytest.safe_execution_op_cst_has_run = False
+    assert pipe_.safe_execute(1, twz_nodes=["op1"]) == (5, None)
+    assert pytest.safe_execution_c == 1
+    assert pytest.safe_execution_op_cst_has_run == False
+
+    assert pipe_.safe_execute(2, twz_nodes=["op1"]) == (5, None)
+    assert pytest.safe_execution_c == 1
+    assert pytest.safe_execution_op_cst_has_run == False
+
+
+test_subgraph_with_safe_execution_with_setup()

--- a/tests/test_safe_execution.py
+++ b/tests/test_safe_execution.py
@@ -3,7 +3,7 @@ from time import sleep
 
 import pytest
 
-from tawazi import _to_dag, op
+from tawazi import op, to_dag
 
 """integration tests"""
 
@@ -41,7 +41,7 @@ b_op = op(b)
 c_op = op(c)
 
 # run in the dag interface
-@_to_dag
+@to_dag
 def dagger():
     a_ = a_op()
     b_ = b_op()
@@ -57,14 +57,12 @@ def test_normal_execution_without_dag():
 def test_dag_execution():
     for i in range(10):
         pytest.safe_execution_val = ""
-        dag = dagger()
-        dag.max_concurrency = 1
-        dag.execute()
+        dagger.max_concurrency = 1
+        dagger()
         assert pytest.safe_execution_val == "ABC", f"during {i}th iteration"
 
 
 def test_safe_execution():
     pytest.safe_execution_val = ""
-    dag = dagger()
-    dag.safe_execute()
+    dagger.safe_execute()
     assert pytest.safe_execution_val in ["ABC", "BAC"]

--- a/tests/test_setup_nodes.py
+++ b/tests/test_setup_nodes.py
@@ -292,6 +292,9 @@ def test_pipeline_setup_method():
     assert pytest.op12 == 0
 
 
+test_pipeline_setup_method()
+
+
 def test_setup_node_cst_input():
     @op(setup=True)
     def setop(k: int = 1234):

--- a/tests/test_setup_nodes.py
+++ b/tests/test_setup_nodes.py
@@ -292,9 +292,6 @@ def test_pipeline_setup_method():
     assert pytest.op12 == 0
 
 
-test_pipeline_setup_method()
-
-
 def test_setup_node_cst_input():
     @op(setup=True)
     def setop(k: int = 1234):

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -73,35 +73,35 @@ def dag_describer():
 def test_dag_subgraph_all_nodes():
     pytest.subgraph_comp_str = ""
     dag = dag_describer
-    results = dag.execute([a, b, c, d, e, f, g, h, i])
+    results = dag._execute([a, b, c, d, e, f, g, h, i])
     assert set("abcdefghi") == set(pytest.subgraph_comp_str)
 
 
 def test_dag_subgraph_leaf_nodes():
     pytest.subgraph_comp_str = ""
     dag = dag_describer
-    results = dag.execute([b, d, f, g, i])
+    results = dag._execute([b, d, f, g, i])
     assert set("abcdefghi") == set(pytest.subgraph_comp_str)
 
 
 def test_dag_subgraph_leaf_nodes_with_extra_nodes():
     pytest.subgraph_comp_str = ""
     dag = dag_describer
-    results = dag.execute([b, c, e, h, g])
+    results = dag._execute([b, c, e, h, g])
     assert set("abcegh") == set(pytest.subgraph_comp_str)
 
 
 def test_dag_subgraph_nodes_ids():
     pytest.subgraph_comp_str = ""
     dag = dag_describer
-    results = dag.execute([b.id, c.id, e.id, h.id, g.id])
+    results = dag._execute([b.id, c.id, e.id, h.id, g.id])
     assert set("abcegh") == set(pytest.subgraph_comp_str)
 
 
 def test_dag_subgraph_non_existing_nodes_ids():
     with pytest.raises(ValueError, match="nodes are not in the graph"):
         dag = dag_describer
-        results = dag.execute(["gibirish"])
+        results = dag._execute(["gibirish"])
 
 
 # TODO: fix this problem!!!

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -1,7 +1,7 @@
 #  type: ignore
 import pytest
 
-from tawazi import _to_dag, op, to_dag
+from tawazi import op, to_dag
 from tawazi.errors import TawaziBaseException
 
 """integration test"""
@@ -55,7 +55,7 @@ def i(h):
     pytest.subgraph_comp_str += "i"
 
 
-@_to_dag
+@to_dag
 def dag_describer():
     var_a = a()
     var_b = b(var_a)
@@ -72,39 +72,39 @@ def dag_describer():
 
 def test_dag_subgraph_all_nodes():
     pytest.subgraph_comp_str = ""
-    dag = dag_describer()
+    dag = dag_describer
     results = dag.execute([a, b, c, d, e, f, g, h, i])
     assert set("abcdefghi") == set(pytest.subgraph_comp_str)
 
 
 def test_dag_subgraph_leaf_nodes():
     pytest.subgraph_comp_str = ""
-    dag = dag_describer()
+    dag = dag_describer
     results = dag.execute([b, d, f, g, i])
     assert set("abcdefghi") == set(pytest.subgraph_comp_str)
 
 
 def test_dag_subgraph_leaf_nodes_with_extra_nodes():
     pytest.subgraph_comp_str = ""
-    dag = dag_describer()
+    dag = dag_describer
     results = dag.execute([b, c, e, h, g])
     assert set("abcegh") == set(pytest.subgraph_comp_str)
 
 
 def test_dag_subgraph_nodes_ids():
     pytest.subgraph_comp_str = ""
-    dag = dag_describer()
+    dag = dag_describer
     results = dag.execute([b.id, c.id, e.id, h.id, g.id])
     assert set("abcegh") == set(pytest.subgraph_comp_str)
 
 
 def test_dag_subgraph_non_existing_nodes_ids():
     with pytest.raises(ValueError, match="nodes are not in the graph"):
-        dag = dag_describer()
+        dag = dag_describer
         results = dag.execute(["gibirish"])
 
 
-# TODO: fix this test
+# TODO: fix this problem!!!
 # def test_dag_subgraph_nodes_with_usage():
 #     @to_dag
 #     def pipe_duplication():

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -33,6 +33,3 @@ def test_call_tag():
     assert pipe() == 12
     assert pipe.get_nodes_by_tag("another_a_tag") == [pipe.get_node_by_id("a")]
     assert pipe.get_nodes_by_tag("another_b_tag") == [pipe.get_node_by_id("b")]
-
-
-test_call_tag()

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -21,3 +21,18 @@ def test_tag():
     assert pipe() == 1236
     assert pipe.get_nodes_by_tag("b") == [pipe.get_node_by_id("a")]
     assert pipe.get_nodes_by_tag(("op", "b", "takes argument a")) == [pipe.get_node_by_id("b")]
+
+
+def test_call_tag():
+    @to_dag
+    def pipe():
+        a_ = a(10, twz_tag="another_a_tag")
+        b_ = b(a_, twz_tag="another_b_tag")
+        return b_
+
+    assert pipe() == 12
+    assert pipe.get_nodes_by_tag("another_a_tag") == [pipe.get_node_by_id("a")]
+    assert pipe.get_nodes_by_tag("another_b_tag") == [pipe.get_node_by_id("b")]
+
+
+test_call_tag()


### PR DESCRIPTION
# Description

* document the new parts of the code to be more clean. 
* Merge PreComputedExecNode and ArgExecNode
* Separate helpers functions into `helpers.py`
* remove the deprecated to_dag and only use the new to_dag interface
* Introduce NoVal a special variable that indicates the lack of a variable
* safe_execute has the same interface as `__call__`
