### PR TITLE
V0.3/NoVal

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Run tests
       run: |
         set -o pipefail
-        poetry run pytest --cov=tawazi --cov-report=term-missing:skip-covered tests/ | tee pytest-coverage.txt
+        poetry run pytest --doctest-modules --cov=tawazi --cov-report=term-missing:skip-covered tests/ | tee pytest-coverage.txt
         # test extracted python code from markdown
         poetry run python tests/test_md.py
 

--- a/example.py
+++ b/example.py
@@ -5,7 +5,7 @@ from typing import Union
 
 import pytest
 
-from tawazi import _to_dag, op
+from tawazi import op, to_dag
 
 
 @op
@@ -41,7 +41,7 @@ def d(b, c, third_argument: Union[str, int] = 1234, fourth_argument=6789):
     return "d"
 
 
-@_to_dag
+@to_dag
 def my_custom_dag():
     vara = a()
     varb = b(vara)
@@ -65,7 +65,7 @@ def f(a, b, c, d, e):
     print("ran f")
 
 
-@_to_dag
+@to_dag
 def my_other_custom_dag():
     vara = a()
     varb = b(vara)
@@ -75,23 +75,23 @@ def my_other_custom_dag():
     _varf = f(vara, varb, varc, vard, vare)
 
 
-d1 = my_custom_dag()
+d1 = my_custom_dag
 print("\n1st execution of dag")
-d1.execute()
+d1()
 assert pytest.third_argument == 1234
 assert pytest.fourth_argument == 1111
 print("\n2nd execution of dag")
-d1.execute()
+d1()
 
-d2 = my_other_custom_dag()
+d2 = my_other_custom_dag
 print("\n1st execution of other dag")
-d2.execute()
+d2()
 assert pytest.third_argument == "blabla"
 assert pytest.fourth_argument == 2222
 print("\n2nd execution of other dag")
-d2.execute()
+d2()
 
 print("\n3rd execution of dag")
-d1.execute()
+d1()
 assert pytest.third_argument == 1234
 assert pytest.fourth_argument == 1111

--- a/tawazi/consts.py
+++ b/tawazi/consts.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 IdentityHash = str
 Tag = Union[None, str, tuple]  # anything immutable
@@ -10,3 +10,42 @@ ARG_NAME_SEP = ">>>"
 USE_SEP_START = "<<"
 USE_SEP_END = ">>"
 ReturnIDsType = Optional[Union[List[IdentityHash], Tuple[IdentityHash], IdentityHash]]
+
+
+class NoValType:
+    """
+    Tawazi's special None.
+    This class is a singleton similar to None to determine that no value is assigned
+    >>> NoVal1 = NoValType()
+    >>> NoVal2 = NoValType()
+    >>> assert NoVal1 is NoVal2
+    >>> from copy import deepcopy, copy
+    >>> assert NoVal1 is deepcopy(NoVal1)
+    >>> assert NoVal1 is copy(NoVal1)
+    >>> assert NoVal1 != NoVal1
+    """
+
+    _instance = None
+
+    def __new__(cls: Type["NoValType"]) -> "NoValType":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __bool__(self) -> bool:
+        return False
+
+    def __repr__(self) -> str:
+        return "NoVal"
+
+    def __eq__(self, __o: object) -> bool:
+        return False
+
+    def __copy__(self) -> "NoValType":
+        return self
+
+    def __deepcopy__(self, _prev: Dict[Any, Any]) -> "NoValType":
+        return self
+
+
+NoVal = NoValType()

--- a/tawazi/dag.py
+++ b/tawazi/dag.py
@@ -652,7 +652,6 @@ class DAG:
                 node_id = self.input_ids[ind_arg]
 
                 call_xn_dict[node_id].result = arg
-                call_xn_dict[node_id].executed = True
 
         return call_xn_dict
 

--- a/tawazi/helpers.py
+++ b/tawazi/helpers.py
@@ -1,7 +1,7 @@
 import inspect
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict, List, Tuple, Union
 
-from tawazi.consts import USE_SEP_END, USE_SEP_START, IdentityHash
+from tawazi.consts import USE_SEP_END, USE_SEP_START, IdentityHash, NoVal, NoValType
 
 
 def ordinal(numb: int) -> str:
@@ -52,7 +52,7 @@ def get_args_and_default_args(func: Callable[..., Any]) -> Tuple[List[str], Dict
          and the mapping between the arguments and their default value for default arguments
     >>> def f(a1, a2, *args, d1=123, d2=None): pass
     >>> get_args_and_default_args(f)
-    >>> (['a1', 'a2', 'args'], {'d1': 123, 'd2': None})
+    (['a1', 'a2', 'args'], {'d1': 123, 'd2': None})
     """
     signature = inspect.signature(func)
     args = []
@@ -71,3 +71,9 @@ def lazy_xn_id(base_id: IdentityHash, count_usages: int) -> IdentityHash:
         return f"{base_id}{USE_SEP_START}{count_usages}{USE_SEP_END}"
 
     return base_id
+
+
+def filter_NoVal(v: Union[NoValType, Any]) -> Any:
+    if v is NoVal:
+        return None
+    return v

--- a/tawazi/node.py
+++ b/tawazi/node.py
@@ -88,9 +88,9 @@ class ExecNode:
         self.result: Union[NoValType, Any] = NoVal
         # even though setting result to NoVal is not necessary... it clarifies debugging
 
-        # self.executed can be removed...
-        #  it can be a property that checks if self.result is not NoVal
-        self.executed = False
+    @property
+    def executed(self) -> bool:
+        return self.result is not NoVal
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__} {self.id} ~ | <{hex(id(self))}>"
@@ -128,7 +128,6 @@ class ExecNode:
 
         # 2. write the result
         self.result = self.exec_function(*args, **kwargs)
-        self.executed = True
 
         # 3. useless return value
         logger.debug(f"Finished executing {self.id} with task {self.exec_function}")
@@ -212,7 +211,6 @@ class ArgExecNode(ExecNode):
 
         if value is not NoVal:
             self.result = value
-            self.executed = True
 
 
 class LazyExecNode(ExecNode):


### PR DESCRIPTION
# Description

Stability enhancement

Fixes # (issue)

ExecNode.executed wasn't linked to self.result. This was potentially error prone in the future.
To help mitigate this issue, we include `NoVal`. 
`NoVal` is a singleton that acts the same way as None but is specific to Tawazi and shouldn't be used by the outside user (It is not exposed in the interface).
if self.result equals NoVal then ExecNode.result is not calculated yet.
  

## Type of change

Please delete options that are not relevant.

- [x] add doctest to the list of tests
- [x] fix example.py
- [x] introduce NoVal
- [x] make ExecNode.executed a property of ExecNode dependent on ExecNode.result
