### PR TITLE
[FEATURE] Scheduled Nodes

### DIFF
--- a/tests/test_dagexecutor.py
+++ b/tests/test_dagexecutor.py
@@ -38,10 +38,12 @@ def test_run_whole_dag_executor():
 
 
 def test_run_dag_executor_multiple_times():
-    # even though this is not guaranteed to work... but executors should be reusable but are not threadsafe!
+    # executors are used only once!
     executor = pipe.executor()
     r1, r2, r3 = executor(1, 2)
+    executor = pipe.executor()
     r4, r5, r6 = executor(3, 4)
+    executor = pipe.executor()
     r7, r8, r9 = executor(5, 6)
 
     assert (r1, r2, r3, r4, r5, r6, r7, r8, r9) == (2, 4, 6, 4, 6, 10, 6, 8, 14)
@@ -72,3 +74,9 @@ def test_thread_naming():
     # should fail
     with pytest.raises(AssertionError):
         pipe.executor(call_id="tough")()
+
+
+def test_scheduled_nodes():
+    executor = pipe.executor(target_nodes=["xn1", "xn2"])
+    assert {"xn1", "xn2"}.issubset(set(executor.scheduled_nodes))
+    assert "xn3" not in set(executor.scheduled_nodes)

--- a/tests/test_exclude_nodes.py
+++ b/tests/test_exclude_nodes.py
@@ -104,9 +104,11 @@ def test_with_setup_nodes():
     pipe_.setup(exclude_nodes=[e])
     assert pytest.test_exclude_nodes.count("z") == 1
 
+    pipe_exec = pipe_.executor(exclude_nodes=[e])
     assert (None, "bc", "bd", "bcbdg") == pipe_exec()
     assert pytest.test_exclude_nodes.count("z") == 1
 
+    pipe_exec = pipe_.executor(exclude_nodes=[e])
     assert ("zef", "bc", "bd", "bcbdg") == pipe_()
     assert pytest.test_exclude_nodes.count("z") == 1
 
@@ -137,9 +139,5 @@ def test_with_debug_nodes():
 
 
 def test_impossible_situation():
-    pipe_exec = pipe.executor(target_nodes=[g], exclude_nodes=[d])
     with pytest.raises(TawaziUsageError):
-        pipe_exec()
-
-
-# test_excludenodes_basic()
+        _ = pipe.executor(target_nodes=[g], exclude_nodes=[d])

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -70,6 +70,20 @@ def dag_describer():
     var_i = i(var_h)
 
 
+def test_scheduled_nodes():
+    executor = dag_describer.executor(target_nodes=["a"])
+    assert {"a"} == set(executor.scheduled_nodes)
+
+    executor = dag_describer.executor(target_nodes=["b"])
+    assert {"a", "b"} == set(executor.scheduled_nodes)
+
+    executor = dag_describer.executor(target_nodes=["c"])
+    assert {"a", "c"} == set(executor.scheduled_nodes)
+
+    executor = dag_describer.executor(target_nodes=["d"])
+    assert {"a", "c", "d"} == set(executor.scheduled_nodes)
+
+
 def test_dag_subgraph_all_nodes():
     pytest.subgraph_comp_str = ""
     dag = dag_describer


### PR DESCRIPTION
# Description

attribute `DAGExecution.scheduled_nodes` specifies the XNodes that will run. 
Now DAGExecution is restricted to run a single time only!

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature DAGExecution.scheduled_nodes
- [x] New feature DAGExecution can not run twice

