### PR TITLE
new: :sparkles: :recycle: refacto of the graph building interface and implement root nodes

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -533,6 +533,7 @@ pipe_exec()
 Additionally, you can build a subgraph with the paths you want to include by declaring the root nodes where those paths 
 begin, with the `root_nodes` argument:
 
+<!--pytest-codeblocks:cont-->
 ```python
 pipe_exec = pipeline.executor(root_nodes=["b"])  # will select all nodes depending on "b"
 pipe_exec()

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -530,7 +530,14 @@ pipe_exec()
 
     Because `DAGExecution` instances are mutable, they are non thread-safe. This is unlike `DAG` which is ThreadSafe
 
+Additionally, you can build a subgraph with the paths you want to include by declaring the root nodes where those paths 
+begin, with the `root_nodes` argument:
 
+```python
+pipe_exec = pipeline.executor(root_nodes=["b"])  # will select all nodes depending on "b"
+pipe_exec()
+```
+This can of course be combined with `target_nodes`, allowing to select only specific parts of the graph.
 
 ### **Basic Operations between nodes**
 `UsageExecNode` implements almost all basic operations (addition, substraction, ...).

--- a/tawazi/_dag/dag.py
+++ b/tawazi/_dag/dag.py
@@ -639,18 +639,14 @@ class DAG(Generic[P, RVDAG]):
             target_ids = self._sanitize_nodes_alias(target_nodes)
             graph.subgraph_leaves(target_ids)
 
-        # handle debug nodes
         if cfg.RUN_DEBUG_NODES:
-            # after extending leaves_ids, we should do a recheck because this might recreate another debug-able XN...
-            target_ids = self._extend_leaves_ids_debug_xns(graph.leaf_nodes)
+            # find original debug nodes
+            debug_ids = self._extend_leaves_ids_debug_xns(graph.leaf_nodes)
 
             # extend the graph with the debug XNs
-            # This is not efficient but it is ok since we are debugging the code anyways
-            debug_graph = deepcopy(self.graph_ids)
-            debug_graph.subgraph_leaves(list(graph.nodes) + target_ids)
-            graph = debug_graph
+            graph = self.graph_ids.subgraph(list(graph.nodes()) + debug_ids).copy()
 
-        # 3. Remove debug execnodes
+        # 3. Remove debug nodes
         else:
             graph.remove_nodes_from([node_id for node_id in graph if self.node_dict[node_id].debug])
 

--- a/tawazi/_dag/digraph.py
+++ b/tawazi/_dag/digraph.py
@@ -1,5 +1,4 @@
 """Module containing the definition of a Directed Graph Extension of networkx.DiGraph."""
-from copy import deepcopy
 from itertools import chain
 from typing import Iterable, List, Optional, Sequence, Set, Tuple
 
@@ -170,25 +169,3 @@ class DiGraphEx(nx.DiGraph):
         for node in nodes:
             ancestors.update(nx.ancestors(self, node))
         return ancestors
-
-
-def subgraph(graph: DiGraphEx, leaves_ids: Optional[List[Identifier]]) -> DiGraphEx:
-    """Deep copy the same graph if leaves_ids is None, otherwise returns a new graph by applying `graph.subgraph_leaves`.
-
-    Args:
-        graph (DiGraphEx): graph describing the DAG
-        leaves_ids (List[Identifier]): The leaves that must be executed
-
-    Returns:
-        DiGraphEx: The subgraph of the provided graph
-    """
-    # TODO: avoid mutable state, hence avoid doing deep copies ?
-    # 0. deep copy the graph ids because it will be pruned during calculation
-    graph = deepcopy(graph)
-
-    # TODO: make the creation of subgraph possible directly from initialization
-    # 1. create the subgraph
-    if leaves_ids is not None:
-        graph.subgraph_leaves(leaves_ids)
-
-    return graph

--- a/tawazi/_dag/helpers.py
+++ b/tawazi/_dag/helpers.py
@@ -93,7 +93,7 @@ def execute(
 
     # 0.4 get the candidates root nodes that can be executed
     # runnable_nodes_ids will be empty if all root nodes are running
-    runnable_xns_ids = graph.root_nodes()
+    runnable_xns_ids = graph.root_nodes
 
     with ThreadPoolExecutor(max_workers=max_concurrency, thread_name_prefix=call_id) as executor:
         while len(graph):
@@ -126,7 +126,7 @@ def execute(
                     graph.remove_node(id_)
 
             # 2. list the root nodes that aren't being executed
-            runnable_xns_ids = list(set(graph.root_nodes()) - set(futures.keys()))
+            runnable_xns_ids = list(set(graph.root_nodes) - set(futures.keys()))
 
             # 3. if no runnable node exist, go to step 6 (wait for a node to finish)
             #   (This **might** create a new root node)

--- a/tests/test_digraphex.py
+++ b/tests/test_digraphex.py
@@ -1,0 +1,73 @@
+import pytest
+from tawazi._dag.digraph import DiGraphEx
+
+
+@pytest.fixture
+def graph() -> DiGraphEx:
+    g = DiGraphEx()
+    g.add_nodes_from([1, 2, 3, 4, 5, 6, 7])
+    g.add_edges_from([(1, 2), (1, 3), (4, 5), (5, 6), (4, 7)])
+    return g
+
+
+@pytest.fixture
+def graph_cycle() -> DiGraphEx:
+    g = DiGraphEx()
+    g.add_nodes_from([1, 2, 3, 4, 5, 6, 7])
+    g.add_edges_from([(1, 2), (1, 3), (4, 5), (5, 6), (4, 7), (6, 5)])
+    return g
+
+
+def test_digraph_nodes(graph: DiGraphEx) -> None:
+    assert graph.root_nodes == [1, 4]  # type: ignore[comparison-overlap]
+    assert graph.leaf_nodes == [2, 3, 6, 7]  # type: ignore[comparison-overlap]
+
+
+def test_digraph_succ_one_node(graph: DiGraphEx) -> None:
+    succs = graph.single_node_successors(1)  # type: ignore[arg-type]
+    assert succs == [1, 2, 3]  # type: ignore[comparison-overlap]
+
+
+def test_digraph_succ_several_nodes(graph: DiGraphEx) -> None:
+    succs = graph.multiple_nodes_successors([1, 5])  # type: ignore[list-item]
+    assert succs == {1, 2, 3, 5, 6}  # type: ignore[comparison-overlap]
+
+
+def test_graph_remove_recursively(graph: DiGraphEx) -> None:
+    h = DiGraphEx(graph)
+    h.remove_recursively(1)  # type: ignore[arg-type]
+    assert set(h.nodes) == {4, 5, 6, 7}
+
+
+def test_graph_remove_recursively_without_root(graph: DiGraphEx) -> None:
+    h = DiGraphEx(graph)
+    h.remove_recursively(1, remove_root_node=False)  # type: ignore[arg-type]
+    assert set(h.nodes) == {1, 4, 5, 6, 7}
+
+
+def test_no_cycle(graph: DiGraphEx) -> None:
+    assert not graph._find_cycle()
+
+
+def test_cycle(graph_cycle: DiGraphEx) -> None:
+    assert graph_cycle._find_cycle() is not None
+
+
+def test_subgraph_leaves(graph: DiGraphEx) -> None:
+    h = DiGraphEx(graph)
+    h.subgraph_leaves([4, 5, 6, 7])  # type: ignore[list-item]
+    assert set(h.nodes) == {4, 5, 6, 7}
+    assert list(h.edges) == [(4, 5), (4, 7), (5, 6)]
+
+    with pytest.raises(ValueError):
+        h.subgraph_leaves(["zaza", "zozo"])
+
+
+def test_topological_sort(graph: DiGraphEx) -> None:
+    ts = graph.topologically_sorted
+    assert ts == [1, 4, 2, 3, 5, 7, 6]  # type: ignore[comparison-overlap]
+
+
+def test_ancestors_of_iter(graph: DiGraphEx) -> None:
+    anc = graph.ancestors_of_iter([6])  # type: ignore[list-item]
+    assert anc == {4, 5}  # type: ignore[comparison-overlap]

--- a/tests/test_exclude_nodes.py
+++ b/tests/test_exclude_nodes.py
@@ -4,7 +4,6 @@ from typing import Tuple
 import pytest
 from tawazi import dag, xn
 from tawazi.config import cfg
-from tawazi.errors import TawaziUsageError
 
 test_exclude_nodes = ""
 
@@ -155,5 +154,5 @@ def test_with_debug_nodes() -> None:
 
 
 def test_impossible_situation() -> None:
-    with pytest.raises(TawaziUsageError):
+    with pytest.raises(ValueError):
         _ = pipe.executor(target_nodes=[g], exclude_nodes=[d])

--- a/tests/test_root_nodes.py
+++ b/tests/test_root_nodes.py
@@ -1,0 +1,59 @@
+import pytest
+from tawazi import dag, xn
+
+
+@xn
+def add(ar: str, br: str) -> str:
+    return ar + br
+
+
+@xn
+def v() -> int:
+    return 1
+
+
+@xn
+def v1(a: int) -> int:
+    return 1
+
+
+@xn
+def v2(e: int) -> int:
+    return 1
+
+
+@xn
+def v3(f: int) -> int:
+    return 1
+
+
+@xn
+def a() -> str:
+    return "q"
+
+
+@xn
+def c() -> int:
+    return 3
+
+
+@dag
+def d() -> int:
+    titi = c()
+    _a = a()
+    add(_a, "b")
+    va = v()
+    vb = v1(va)
+    vc = v2(vb)
+    v3(vc)
+    return titi
+
+
+def test_with_root_nodes() -> None:
+    dx = d.executor(root_nodes=["v"])
+    assert set(dx.graph.nodes) == {"v", "v1", "v2", "v3"}
+
+
+def test_failing_roots() -> None:
+    with pytest.raises(ValueError):
+        d.executor(root_nodes=["v2"])


### PR DESCRIPTION
# Description

This PR refactors a lot of the graph creation interface leveraging other functions from networkx and implements the possibility of running only a subgraph from a root node


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
