### PR TITLE
Improve objects interface

### DIFF
--- a/tawazi/_dag/dag.py
+++ b/tawazi/_dag/dag.py
@@ -422,21 +422,17 @@ class DAG(Generic[P, RVDAG]):
                 and the root nodes is logical.
         """
         # 1. if target_nodes is not provided run all setup ExecNodes
-        target_nodes = (
-            self.graph_ids.setup_nodes
-            if target_nodes is None
-            else self.get_multiple_nodes_aliases(target_nodes)
-        )
+        if target_nodes is not None:
+            target_nodes = self.get_multiple_nodes_aliases(target_nodes)
+        else:
+            target_nodes = self.graph_ids.setup_nodes
 
         # 2. the leaves_ids that the user wants to execute
-        exclude_nodes = (
-            self.get_multiple_nodes_aliases(exclude_nodes)
-            if exclude_nodes is not None
-            else exclude_nodes
-        )
-        root_nodes = (
-            self.get_multiple_nodes_aliases(root_nodes) if root_nodes is not None else root_nodes
-        )
+        if exclude_nodes is not None:
+            exclude_nodes = self.get_multiple_nodes_aliases(exclude_nodes)
+
+        if root_nodes is not None:
+            root_nodes = self.get_multiple_nodes_aliases(root_nodes)
 
         graph = self.graph_ids.make_subgraph(
             target_nodes=target_nodes, exclude_nodes=exclude_nodes, root_nodes=root_nodes
@@ -487,8 +483,8 @@ class DAG(Generic[P, RVDAG]):
 
         # add debug nodes
         if cfg.RUN_DEBUG_NODES:
-            debug_ids = self.graph_ids.include_debug_nodes(graph.leaf_nodes)
-            graph = self.graph_ids.subgraph(list(graph.nodes) + debug_ids).copy()
+            debug_nodes = self.graph_ids.include_debug_nodes(graph.leaf_nodes)
+            graph = self.graph_ids.subgraph(list(graph.nodes) + debug_nodes).copy()
 
         # 3. Remove debug nodes
         else:
@@ -652,24 +648,19 @@ class DAGExecution(Generic[P, RVDAG]):
             self.graph = self.dag.graph_ids.make_subgraph(target_nodes=cache_deps_of)
         else:
             # clean user input
-            target_nodes = (
-                self.dag.get_multiple_nodes_aliases(self.target_nodes)
-                if self.target_nodes is not None
-                else self.target_nodes
-            )
-            exclude_nodes = (
-                self.dag.get_multiple_nodes_aliases(self.exclude_nodes)
-                if self.exclude_nodes is not None
-                else self.exclude_nodes
-            )
-            root_nodes = (
-                self.dag.get_multiple_nodes_aliases(self.root_nodes)
-                if self.root_nodes is not None
-                else self.root_nodes
-            )
+            if self.target_nodes is not None:
+                self.target_nodes = self.dag.get_multiple_nodes_aliases(self.target_nodes)
+
+            if self.exclude_nodes is not None:
+                self.exclude_nodes = self.dag.get_multiple_nodes_aliases(self.exclude_nodes)
+
+            if self.root_nodes is not None:
+                self.root_nodes = self.dag.get_multiple_nodes_aliases(self.root_nodes)
 
             self.graph = self.dag.graph_ids.make_subgraph(
-                target_nodes=target_nodes, exclude_nodes=exclude_nodes, root_nodes=root_nodes
+                target_nodes=self.target_nodes,
+                exclude_nodes=self.exclude_nodes,
+                root_nodes=self.root_nodes,
             )
 
         if cfg.RUN_DEBUG_NODES:

--- a/tawazi/_dag/digraph.py
+++ b/tawazi/_dag/digraph.py
@@ -147,7 +147,7 @@ class DiGraphEx(nx.DiGraph):
         Returns:
             A set of tags
         """
-        return set(chain([tags for _, tags in self.nodes(data="tag")]))
+        return set(chain(*[tags for _, tags in self.nodes(data="tag")]))
 
     @property
     def topologically_sorted(self) -> List[Identifier]:

--- a/tawazi/_dag/digraph.py
+++ b/tawazi/_dag/digraph.py
@@ -6,6 +6,7 @@ from typing import Dict, Iterable, List, Optional, Sequence, Set
 import networkx as nx
 from networkx import NetworkXNoCycle, NetworkXUnfeasible, find_cycle
 
+from tawazi.config import Config
 from tawazi.consts import Identifier, Tag
 from tawazi.errors import TawaziUsageError
 from tawazi.node import ExecNode, UsageExecNode
@@ -239,6 +240,28 @@ class DiGraphEx(nx.DiGraph):
                             # this new XN can run by only running the current leaves_ids
                             leaves_ids.append(successor_id)
         return leaves_ids
+
+    def extend_graph_with_debug_nodes(
+        self, original_graph: "DiGraphEx", cfg: Config
+    ) -> "DiGraphEx":
+        """Add or remove debug nodes depending on the configuration.
+
+        Args:
+            original_graph: the graph containing a broader set of nodes
+            cfg: the tawazi configuration
+
+        Returns:
+            the correct subgraph
+        """
+        if cfg.RUN_DEBUG_NODES:
+            nodes_to_include = original_graph.include_debug_nodes(self.leaf_nodes) + list(
+                self.nodes
+            )
+        else:
+            nodes_to_include = list(set(self.nodes) - set(self.debug_nodes))
+
+        # networkx typing problem
+        return original_graph.subgraph(nodes_to_include).copy()  # type: ignore[no-any-return]
 
     def minimal_induced_subgraph(self, nodes: List[Identifier]) -> "DiGraphEx":
         """Get the minimal induced subgraph containing the provided nodes.

--- a/tawazi/_dag/digraph.py
+++ b/tawazi/_dag/digraph.py
@@ -147,7 +147,7 @@ class DiGraphEx(nx.DiGraph):
         Returns:
             A set of tags
         """
-        return set(chain(*[tags for _, tags in self.nodes(data="tag")]))
+        return set(chain(*(tags for _, tags in self.nodes(data="tag"))))
 
     @property
     def topologically_sorted(self) -> List[Identifier]:

--- a/tests/test_edge_cases_dag.py
+++ b/tests/test_edge_cases_dag.py
@@ -34,7 +34,7 @@ def test_same_constant_name_in_two_exec_nodes() -> None:
         var_a = a(1234)
         b(var_a, "poulpe")
 
-    exec_nodes = shortcut_execute(my_dag, my_dag.make_subgraph())
+    exec_nodes = shortcut_execute(my_dag, my_dag.graph_ids.make_subgraph())
     assert len(exec_nodes) == 4
     assert exec_nodes[a.id].result == 1234
     assert exec_nodes[b.id].result == "1234poulpe"

--- a/tests/test_exclude_nodes.py
+++ b/tests/test_exclude_nodes.py
@@ -142,8 +142,6 @@ def test_with_debug_nodes() -> None:
 
     cfg.RUN_DEBUG_NODES = True
     assert ("aef", "bc", "bd", "bcbdg") == pipe()
-    # TODO: write clear documentation about priority of choosing exclude_nodes vs debug_nodes
-    #  (debug_nodes are more prioritized!)
     exec_ = pipe.executor(exclude_nodes=[g])
     assert ("aef", "bc", "bd", "bcbdg") == exec_()
     exec_ = pipe.executor(exclude_nodes=[b])

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -109,7 +109,7 @@ def test_dag_subgraph_all_nodes() -> None:
     nodes: List[ExecNode] = [a, b, c, d, e, f, g, h, i]
     nodes_ids = [n.id for n in nodes]
 
-    graph = dag.make_subgraph(nodes_ids)
+    graph = dag.graph_ids.make_subgraph(nodes_ids)
     shortcut_execute(dag, graph)
     assert set("abcdefghi") == set(subgraph_comp_str)
 
@@ -121,7 +121,7 @@ def test_dag_subgraph_leaf_nodes() -> None:
     nodes: List[ExecNode] = [b, d, f, g, i]
     nodes_ids: List[str] = [n.id for n in nodes]
 
-    graph = dag.make_subgraph(nodes_ids)
+    graph = dag.graph_ids.make_subgraph(nodes_ids)
     shortcut_execute(dag, graph)
     assert set("abcdefghi") == set(subgraph_comp_str)
 
@@ -133,7 +133,7 @@ def test_dag_subgraph_leaf_nodes_with_extra_nodes() -> None:
     nodes: List[ExecNode] = [b, c, e, h, g]
     nodes_ids = [n.id for n in nodes]
 
-    graph = dag.make_subgraph(nodes_ids)
+    graph = dag.graph_ids.make_subgraph(nodes_ids)
     shortcut_execute(dag, graph)
     assert set("abcegh") == set(subgraph_comp_str)
 
@@ -142,15 +142,15 @@ def test_dag_subgraph_nodes_ids() -> None:
     global subgraph_comp_str
     subgraph_comp_str = ""
     dag = dag_describer
-    graph = dag.make_subgraph([b.id, c.id, e.id, h.id, g.id])
+    graph = dag.graph_ids.make_subgraph([b.id, c.id, e.id, h.id, g.id])
     shortcut_execute(dag, graph)
     assert set("abcegh") == set(subgraph_comp_str)
 
 
 def test_dag_subgraph_non_existing_nodes_ids() -> None:
-    with pytest.raises(ValueError, match="(node or tag gibirish not found)(.|\n)*"):
+    with pytest.raises(ValueError):
         dag = dag_describer
-        graph = dag.make_subgraph(["gibirish"])
+        graph = dag.graph_ids.make_subgraph(["gibirish"])
         shortcut_execute(dag, graph)
 
 

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -18,6 +18,7 @@ def pipe() -> int:
 
 def test_tag() -> None:
     assert pipe() == 1236
+    assert pipe.graph_ids.tags == {"takes argument a", "op", "b"}
     assert pipe.get_nodes_by_tag("b") == [pipe.get_node_by_id("a"), pipe.get_node_by_id("b")]
     assert pipe.get_nodes_by_tag("op") == [pipe.get_node_by_id("b")]
     assert pipe.get_nodes_by_tag("takes argument a") == [pipe.get_node_by_id("b")]


### PR DESCRIPTION
# Description

This PR is about the wip concerning the refacto of the graph building overhaul. In an effort to make the `make_subgraph` method private, I also changed 2-3 things in the way the graph is built. The thing I dont' like is that every call we have to re add/remove debug nodes, + we rely on the deepcopy too much and may have overlooked edge cases, but this will be the work of another PR. This PR adds boilerplate code to achieve the aforementioned goal, which highlights a problem in the design of DAGExecution, its logic being not far away from the dag yet we're obliged to re-do some operations, this will need to be refactored in the future.