### PR TITLE
Refactor node

### DIFF
--- a/tawazi/consts.py
+++ b/tawazi/consts.py
@@ -92,6 +92,10 @@ class NoValType:
         """
         return self
 
+    def __hash__(self) -> int:
+        """Implement hash method in order to make object immutable like."""
+        return id(self)
+
 
 NoVal = NoValType()
 

--- a/tawazi/node/node.py
+++ b/tawazi/node/node.py
@@ -154,7 +154,7 @@ class ExecNode:
                 raise ValueError(
                     f"unpack_to must be a positive int or None, provided {type(self.unpack_to)}"
                 )
-            # yes... empty tuples exist in Python
+            # empty tuple case
             if self.unpack_to < 0:
                 raise ValueError(
                     f"unpack_to must be a positive int or None, provided {self.unpack_to}"

--- a/tawazi/node/node.py
+++ b/tawazi/node/node.py
@@ -40,11 +40,12 @@ from .helpers import _validate_tuple
 exec_nodes: Dict[Identifier, "ExecNode"] = {}
 exec_nodes_lock = Lock()
 
-Alias = Union[Tag, Identifier, "ExecNode"]  # multiple ways of identifying an XN
+# multiple ways of identifying an XN
+Alias = Union[Tag, Identifier, "ExecNode"]
 
 
-def count_occurences(id_: str, exec_nodes: Dict[str, "ExecNode"]) -> int:
-    """Count the number of occurences of an id in exec_nodes.
+def count_occurrences(id_: str, exec_nodes: Dict[str, "ExecNode"]) -> int:
+    """Count the number of occurrences of an id in exec_nodes.
 
     Avoids counting the ids of the arguments passed to previously called ExecNodes.
 
@@ -53,7 +54,7 @@ def count_occurences(id_: str, exec_nodes: Dict[str, "ExecNode"]) -> int:
         exec_nodes (Dict[str, ExecNode]): the dictionary of ExecNodes
 
     Returns:
-        int: the number of occurences of id_ in exec_nodes
+        int: the number of occurrences of id_ in exec_nodes
     """
     # example: id_ = "a"
     # ExecNode a is called five times, hence we should have ids a, a<<1>>, a<<2>>, a<<3>>, a<<4>>
@@ -61,7 +62,6 @@ def count_occurences(id_: str, exec_nodes: Dict[str, "ExecNode"]) -> int:
     # we want to avoid counting "a>>>nth argument" and a<<1>>>>nth argument"
 
     # only choose the ids that are exactly exactly the same as the original id
-    len(id_)
     candidate_ids = (xn_id for xn_id in exec_nodes if xn_id.split(USE_SEP_START)[0] == id_)
 
     # count the number of ids that are exactly the same as the original id
@@ -403,7 +403,6 @@ class ArgExecNode(ExecNode):
         """
         # raises TawaziArgumentException: if this argument is not provided during the Attached ExecNode usage
 
-        # TODO: use pydantic!
         if isinstance(xn_or_func_or_id, ExecNode):
             base_id = xn_or_func_or_id.id
         elif callable(xn_or_func_or_id):
@@ -516,7 +515,7 @@ class LazyExecNode(ExecNode, Generic[P, RVXN]):
         # 1.1 Make a deep copy of self because every Call to an ExecNode corresponds to a new instance
         self_copy = copy(self)
         # 1.2 Assign the id
-        count_usages = count_occurences(self.id, exec_nodes)
+        count_usages = count_occurrences(self.id, exec_nodes)
         # if ExecNode is used multiple times, <<usage_count>> is appended to its ID
         self_copy._id = _lazy_xn_id(self.id, count_usages)
 

--- a/tawazi/node/node.py
+++ b/tawazi/node/node.py
@@ -48,6 +48,10 @@ def count_occurrences(id_: str, exec_nodes: Dict[str, "ExecNode"]) -> int:
     """Count the number of occurrences of an id in exec_nodes.
 
     Avoids counting the ids of the arguments passed to previously called ExecNodes.
+    example: id_ = "a"
+    ExecNode a is called five times, hence we should have ids a, a<<1>>, a<<2>>, a<<3>>, a<<4>>
+    ExecNode a is called with many arguments:
+    we want to avoid counting "a>>>nth argument" and a<<1>>>>nth argument"
 
     Args:
         id_ (str): the id to count
@@ -56,11 +60,6 @@ def count_occurrences(id_: str, exec_nodes: Dict[str, "ExecNode"]) -> int:
     Returns:
         int: the number of occurrences of id_ in exec_nodes
     """
-    # example: id_ = "a"
-    # ExecNode a is called five times, hence we should have ids a, a<<1>>, a<<2>>, a<<3>>, a<<4>>
-    # ExecNode a is called with many arguments:
-    # we want to avoid counting "a>>>nth argument" and a<<1>>>>nth argument"
-
     # only choose the ids that are exactly exactly the same as the original id
     candidate_ids = (xn_id for xn_id in exec_nodes if xn_id.split(USE_SEP_START)[0] == id_)
 

--- a/tawazi/node/node.py
+++ b/tawazi/node/node.py
@@ -143,17 +143,6 @@ class ExecNode:
         if not isinstance(self.resource, Resource):
             raise ValueError(f"resource must be of type {Resource}, provided {type(self.resource)}")
 
-        if not isinstance(self.is_sequential, bool):
-            raise TypeError(
-                f"is_sequential should be of type bool, but {self.is_sequential} provided"
-            )
-
-        if not isinstance(self.debug, bool):
-            raise TypeError(f"debug must be of type bool, but {self.debug} provided")
-
-        if not isinstance(self.setup, bool):
-            raise TypeError(f"setup must be of type bool, but {self.setup} provided")
-
         # other validations
         if self.debug and self.setup:
             raise ValueError(

--- a/tawazi/node/node.py
+++ b/tawazi/node/node.py
@@ -142,6 +142,17 @@ class ExecNode:
         if not isinstance(self.resource, Resource):
             raise ValueError(f"resource must be of type {Resource}, provided {type(self.resource)}")
 
+        if not isinstance(self.is_sequential, bool):
+            raise TypeError(
+                f"is_sequential should be of type bool, but {self.is_sequential} provided"
+            )
+
+        if not isinstance(self.debug, bool):
+            raise TypeError(f"debug must be of type bool, but {self.debug} provided")
+
+        if not isinstance(self.setup, bool):
+            raise TypeError(f"setup must be of type bool, but {self.setup} provided")
+
         # other validations
         if self.debug and self.setup:
             raise ValueError(

--- a/tawazi/node/node.py
+++ b/tawazi/node/node.py
@@ -114,12 +114,6 @@ class ExecNode:
     args: List["UsageExecNode"] = field(default_factory=list)  # args or []
     kwargs: Dict[Identifier, "UsageExecNode"] = field(default_factory=dict)  # kwargs or {}
 
-    # TODO: remove me!!
-    # 3. Assign the name
-    # This can be used in the future but is not particularly useful at the moment
-    __name__: str = field(
-        init=False
-    )  # self.exec_function.__name__ if not isinstance(id_, str) else id_
     # TODO: fix _active behavior!
     _active: Union[bool, "UsageExecNode"] = field(init=False, default=True)
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -48,21 +48,31 @@ def fail(g: Any) -> int:
 
 
 # ExecNodes can be identified using the actual function or an identification string
-en_a = ExecNode(a.__name__, a, is_sequential=True)
-en_b = ExecNode(b.__name__, b, [UsageExecNode(en_a.id)], priority=2, is_sequential=False)
-en_c = ExecNode(c.__name__, c, [UsageExecNode(en_a.id)], priority=1, is_sequential=False)
-en_d = ExecNode(
-    d.__name__, d, [UsageExecNode(en_b.id), UsageExecNode(en_c.id)], priority=1, is_sequential=False
+en_a = ExecNode(id_=a.__name__, exec_function=a, is_sequential=True)
+en_b = ExecNode(
+    id_=b.__name__, exec_function=b, args=[UsageExecNode(en_a.id)], priority=2, is_sequential=False
 )
-en_e = ExecNode(e.__name__, e, [UsageExecNode(en_b.id)], is_sequential=False)
-en_f = ExecNode(f.__name__, f, [UsageExecNode(en_e.id)], is_sequential=False)
-en_g = ExecNode(g.__name__, g, [UsageExecNode(en_e.id)], is_sequential=False)
+en_c = ExecNode(
+    id_=c.__name__, exec_function=c, args=[UsageExecNode(en_a.id)], priority=1, is_sequential=False
+)
+en_d = ExecNode(
+    id_=d.__name__,
+    exec_function=d,
+    args=[UsageExecNode(en_b.id), UsageExecNode(en_c.id)],
+    priority=1,
+    is_sequential=False,
+)
+en_e = ExecNode(id_=e.__name__, exec_function=e, args=[UsageExecNode(en_b.id)], is_sequential=False)
+en_f = ExecNode(id_=f.__name__, exec_function=f, args=[UsageExecNode(en_e.id)], is_sequential=False)
+en_g = ExecNode(id_=g.__name__, exec_function=g, args=[UsageExecNode(en_e.id)], is_sequential=False)
 
 list_execnodes = [en_a, en_b, en_c, en_d, en_e, en_f, en_g]
 node_dict = {xn.id: xn for xn in list_execnodes}
 
 failing_execnodes = list_execnodes + [
-    ExecNode(fail.__name__, fail, [UsageExecNode(en_g.id)], is_sequential=False)
+    ExecNode(
+        id_=fail.__name__, exec_function=fail, args=[UsageExecNode(en_g.id)], is_sequential=False
+    )
 ]
 failing_node_dict = {xn.id: xn for xn in failing_execnodes}
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -22,9 +22,13 @@ def c(b: str) -> str:
     return b + "c"
 
 
-en_a = ExecNode(a.__name__, a, [], is_sequential=True)
-en_b = ExecNode(b.__name__, b, [UsageExecNode(en_a.id)], priority=2, is_sequential=False)
-en_c = ExecNode(c.__name__, c, [UsageExecNode(en_a.id)], priority=1, is_sequential=False)
+en_a = ExecNode(id_=a.__name__, exec_function=a, args=[], is_sequential=True)
+en_b = ExecNode(
+    id_=b.__name__, exec_function=b, args=[UsageExecNode(en_a.id)], priority=2, is_sequential=False
+)
+en_c = ExecNode(
+    id_=c.__name__, exec_function=c, args=[UsageExecNode(en_a.id)], priority=1, is_sequential=False
+)
 en_a.args = [UsageExecNode(en_c.id)]
 
 list_exec_nodes = [en_a, en_b, en_c]

--- a/tests/test_priority_sequential.py
+++ b/tests/test_priority_sequential.py
@@ -47,10 +47,28 @@ def test_priority() -> None:
     global priority_sequential_comp_str
     for _i in range(100):
         priority_sequential_comp_str = ""
-        en_a = ExecNode(a.__name__, a, priority=1, is_sequential=False)
-        en_b = ExecNode(b.__name__, b, [UsageExecNode(en_a.id)], priority=2, is_sequential=False)
-        en_c = ExecNode(c.__name__, c, [UsageExecNode(en_b.id)], priority=2, is_sequential=False)
-        en_d = ExecNode(d.__name__, d, [UsageExecNode(en_a.id)], priority=1, is_sequential=False)
+        en_a = ExecNode(id_=a.__name__, exec_function=a, priority=1, is_sequential=False)
+        en_b = ExecNode(
+            id_=b.__name__,
+            exec_function=b,
+            args=[UsageExecNode(en_a.id)],
+            priority=2,
+            is_sequential=False,
+        )
+        en_c = ExecNode(
+            id_=c.__name__,
+            exec_function=c,
+            args=[UsageExecNode(en_b.id)],
+            priority=2,
+            is_sequential=False,
+        )
+        en_d = ExecNode(
+            id_=d.__name__,
+            exec_function=d,
+            args=[UsageExecNode(en_a.id)],
+            priority=1,
+            is_sequential=False,
+        )
         list_execnodes = [en_a, en_b, en_c, en_d]
         node_dict = {xn.id: xn for xn in list_execnodes}
 
@@ -65,11 +83,35 @@ def test_sequentiality() -> None:
     for _i in range(100):
         # Sequentiality test
         priority_sequential_comp_str = ""
-        en_a = ExecNode(a.__name__, a, is_sequential=False)
-        en_b = ExecNode(b.__name__, b, [UsageExecNode(en_a.id)], priority=2, is_sequential=False)
-        en_c = ExecNode(c.__name__, c, [UsageExecNode(en_a.id)], priority=2, is_sequential=False)
-        en_d = ExecNode(d.__name__, d, [UsageExecNode(en_b.id)], priority=2, is_sequential=False)
-        en_e = ExecNode(e.__name__, e, [UsageExecNode(en_a.id)], priority=1, is_sequential=True)
+        en_a = ExecNode(id_=a.__name__, exec_function=a, is_sequential=False)
+        en_b = ExecNode(
+            id_=b.__name__,
+            exec_function=b,
+            args=[UsageExecNode(en_a.id)],
+            priority=2,
+            is_sequential=False,
+        )
+        en_c = ExecNode(
+            id_=c.__name__,
+            exec_function=c,
+            args=[UsageExecNode(en_a.id)],
+            priority=2,
+            is_sequential=False,
+        )
+        en_d = ExecNode(
+            id_=d.__name__,
+            exec_function=d,
+            args=[UsageExecNode(en_b.id)],
+            priority=2,
+            is_sequential=False,
+        )
+        en_e = ExecNode(
+            id_=e.__name__,
+            exec_function=e,
+            args=[UsageExecNode(en_a.id)],
+            priority=1,
+            is_sequential=True,
+        )
         list_execnodes = [en_a, en_b, en_c, en_d, en_e]
         node_dict = {xn.id: xn for xn in list_execnodes}
 

--- a/tests/test_priority_sequential.py
+++ b/tests/test_priority_sequential.py
@@ -1,8 +1,7 @@
 from time import sleep
 from typing import Any
 
-import pytest
-from tawazi import DAG, ErrorStrategy, xn
+from tawazi import DAG, ErrorStrategy
 from tawazi.node import ExecNode, UsageExecNode
 
 T = 0.01
@@ -128,11 +127,3 @@ def test_sequentiality() -> None:
         assert ind_d > ind_b, f"during {_i}th iteration"
         assert ind_b > ind_a, f"during {_i}th iteration"
         assert ind_c > ind_a, f"during {_i}th iteration"
-
-
-def test_is_sequential_wrong_type() -> None:
-    with pytest.raises(TypeError):
-
-        @xn(is_sequential="bkjfdslkajfsld")  # type: ignore[call-overload]
-        def twinkle() -> None:
-            ...

--- a/tests/test_wrapped_function.py
+++ b/tests/test_wrapped_function.py
@@ -31,7 +31,7 @@ def test_doc_operation() -> None:
 
 
 def test_name_op() -> None:
-    assert abcd.__name__ == "abcd"
+    assert abcd.__name__ == "abcd"  # type: ignore[attr-defined]
 
 
 # TODO: add assertion for type checking after doing some research!


### PR DESCRIPTION
# Description

Use dataclass for ExecNode in order to facilitate reading the code.

We should avoid validating the type of attributes if the type is boolean. We can be happy by using the Truthy value of the attribute. This should never fail for users 

this is why the following code was removed:
```python

        if not isinstance(self.is_sequential, bool):
            raise TypeError(
                f"is_sequential should be of type bool, but {self.is_sequential} provided"
            )

        if not isinstance(self.debug, bool):
            raise TypeError(f"debug must be of type bool, but {self.debug} provided")

        if not isinstance(self.setup, bool):
            raise TypeError(f"setup must be of type bool, but {self.setup} provided")


```


Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
