### PR TITLE
Refacto node

### DIFF
--- a/tawazi/_decorators.py
+++ b/tawazi/_decorators.py
@@ -105,8 +105,15 @@ def xn(
     """
 
     def intermediate_wrapper(_func: Callable[P, RVXN]) -> LazyExecNode[P, RVXN]:
-        lazy_exec_node = LazyExecNode(
-            _func, priority, is_sequential, debug, tag, setup, unpack_to, resource
+        lazy_exec_node: LazyExecNode[P, RVXN] = LazyExecNode(
+            exec_function=_func,
+            priority=priority,
+            is_sequential=is_sequential,
+            debug=debug,
+            tag=tag,
+            setup=setup,
+            unpack_to=unpack_to,
+            resource=resource,
         )
         functools.update_wrapper(lazy_exec_node, _func)
         return lazy_exec_node

--- a/tawazi/_helpers.py
+++ b/tawazi/_helpers.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Dict, List, NoReturn, Tuple, Union
 
 import yaml
 
-from tawazi.consts import USE_SEP_END, USE_SEP_START, Identifier, NoVal, NoValType
+from tawazi.consts import NoVal, NoValType
 from tawazi.errors import _raise_arg_exc
 
 
@@ -78,13 +78,6 @@ def _make_raise_arg_error(func_name: str, arg_name: str) -> Callable[[], NoRetur
         _raise_arg_exc(func_name, arg_name)
 
     return local_func
-
-
-def _lazy_xn_id(base_id: Identifier, count_usages: int) -> Identifier:
-    if count_usages > 0:
-        return f"{base_id}{USE_SEP_START}{count_usages}{USE_SEP_END}"
-
-    return base_id
 
 
 def _filter_noval(v: Union[NoValType, Any]) -> Any:

--- a/tawazi/node/helpers.py
+++ b/tawazi/node/helpers.py
@@ -2,6 +2,7 @@
 from typing import Any, Callable, Optional, Union
 
 from tawazi._helpers import ordinal
+from tawazi.consts import USE_SEP_END, USE_SEP_START, Identifier
 
 
 def _validate_tuple(func: Callable[..., Any], unpack_to: int) -> Optional[bool]:
@@ -42,3 +43,10 @@ def make_suffix(name_or_order: Union[int, str]) -> str:
     if isinstance(name_or_order, int):
         return f"{ordinal(name_or_order)} argument"
     return name_or_order
+
+
+def _lazy_xn_id(base_id: Identifier, count_usages: int) -> Identifier:
+    if count_usages > 0:
+        return f"{base_id}{USE_SEP_START}{count_usages}{USE_SEP_END}"
+
+    return base_id

--- a/tawazi/node/helpers.py
+++ b/tawazi/node/helpers.py
@@ -1,5 +1,7 @@
 """Helpers for node subpackage."""
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Optional, Union
+
+from tawazi._helpers import ordinal
 
 
 def _validate_tuple(func: Callable[..., Any], unpack_to: int) -> Optional[bool]:
@@ -29,3 +31,14 @@ def _validate_tuple(func: Callable[..., Any], unpack_to: int) -> Optional[bool]:
     raise ValueError(
         f"unpack_to must be equal to the number of elements in the type of return ({r_type}) of the function {func}, provided {unpack_to}"
     )
+
+
+def make_suffix(name_or_order: Union[int, str]) -> str:
+    """Create the suffix of the id of ExecNode.
+
+    Args:
+        name_or_order (int | str): The name of the argument or its order of usage in the invocation of the function
+    """
+    if isinstance(name_or_order, int):
+        return f"{ordinal(name_or_order)} argument"
+    return name_or_order

--- a/tawazi/node/node.py
+++ b/tawazi/node/node.py
@@ -142,17 +142,6 @@ class ExecNode:
         if not isinstance(self.resource, Resource):
             raise ValueError(f"resource must be of type {Resource}, provided {type(self.resource)}")
 
-        if not isinstance(self.is_sequential, bool):
-            raise TypeError(
-                f"is_sequential should be of type bool, but {self.is_sequential} provided"
-            )
-
-        if not isinstance(self.debug, bool):
-            raise TypeError(f"debug must be of type bool, but {self.debug} provided")
-
-        if not isinstance(self.setup, bool):
-            raise TypeError(f"setup must be of type bool, but {self.setup} provided")
-
         # other validations
         if self.debug and self.setup:
             raise ValueError(
@@ -254,12 +243,6 @@ class ExecNode:
         # 3. useless return value
         logger.debug("Finished executing %s with task %s", self.id, self.exec_function)
         return self.result
-
-    def _validate(self) -> None:
-        if getattr(self, "debug", None) and getattr(self, "setup", None):
-            raise ValueError(
-                f"The node {self.id} can't be a setup and a debug node at the same time."
-            )
 
 
 class ReturnExecNode(ExecNode):

--- a/tawazi/node/node.py
+++ b/tawazi/node/node.py
@@ -5,7 +5,6 @@ from copy import copy, deepcopy
 from dataclasses import dataclass, field
 from functools import partial, reduce
 from threading import Lock
-from types import MethodType
 from typing import Any, Callable, Dict, Generic, List, NoReturn, Optional, Tuple, Union
 
 from loguru import logger
@@ -449,24 +448,6 @@ class LazyExecNode(ExecNode, Generic[P, RVXN]):
         if self.unpack_to is None:
             return UsageExecNode(self.id)
         return tuple(UsageExecNode(self.id, key=[i]) for i in range(self.unpack_to))
-
-    def __get__(self, instance: "LazyExecNode[P, RVXN]", owner_cls: Optional[Any] = None) -> Any:
-        """Simulate func_descr_get() in Objects/funcobject.c.
-
-        Args:
-            instance (LazyExecNode): the instance that this attribute should be attached to
-            owner_cls: Discriminate between attaching the attribute to the instance of the class and the class itself
-
-        Returns:
-            Either self or a MethodType object
-        """
-        # if LazyExecNode is not an attribute of a class, then return self
-        if instance is None:
-            # this is the case when we call the method on the class instead of an instance of the class
-            # In this case, we must return a "function" hence an instance of this class
-            # https://stackoverflow.com/questions/3798835/understanding-get-and-set-and-python-descriptors
-            return self
-        return MethodType(self, instance)  # func=self  # obj=instance
 
 
 # NOTE: None is hashable! In theory it can be used as a key in a dict!

--- a/tawazi/node/node.py
+++ b/tawazi/node/node.py
@@ -263,24 +263,12 @@ class ReturnExecNode(ExecNode):
         Raises:
             TypeError: if type parameter is passed (Internal)
         """
-        if callable(func):
-            base_id = func
-        else:
-            raise TypeError("ReturnExecNode can only be attached to a Callable")
-
-        if isinstance(name_or_order, str):
-            suffix = name_or_order
-        elif isinstance(name_or_order, int):
-            suffix = f"{ordinal(name_or_order)} argument"
-        else:
-            raise TypeError(
-                f"ReturnExecNode needs the key (str) or order (int) of the returned value, "
-                f"but {name_or_order} of type {type(name_or_order)} is provided"
-            )
-
-        id_ = f"{base_id}{RETURN_NAME_SEP}{suffix}"
-
-        super().__init__(id_=id_, is_sequential=False)
+        suffix = (
+            f"{ordinal(name_or_order)} argument"
+            if isinstance(name_or_order, int)
+            else name_or_order
+        )
+        super().__init__(id_=f"{func}{RETURN_NAME_SEP}{suffix}", is_sequential=False)
 
         self.result = value
 

--- a/tawazi/node/node.py
+++ b/tawazi/node/node.py
@@ -318,10 +318,6 @@ class ArgExecNode(ExecNode):
         self.result = value
 
 
-# NOTE: how can we make a LazyExecNode more configurable ?
-#  This might not be as important as it seems actually because
-#  one can simply create Partial Functions and wrap them in an ExecNode
-# TODO: create a twz_deps reserved variable to support Nothing dependency
 class LazyExecNode(ExecNode, Generic[P, RVXN]):
     """A lazy function simulator.
 


### PR DESCRIPTION
# Description

Reduce the number of lines used to implement ExecNode. 
This was done by removing the constructor for LazyExecNode and removing some useless code inside node.py


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
