### PR TITLE
fix: :bug: node.is_active regression when dag is configured

### DIFF
--- a/tawazi/node/node.py
+++ b/tawazi/node/node.py
@@ -267,8 +267,11 @@ class ExecNode:
 
     def _conf_to_values(self, conf: Dict[str, Any]) -> Dict[str, Any]:
         values = dataclasses.asdict(self)
+        # copy the values of ExecNode that are also dataclass
         values["args"] = self.args
         values["kwargs"] = self.kwargs
+        values["active"] = self.active
+        # modify the values of ExecNode that should be modified
         values["is_sequential"] = conf.get("is_sequential", self.is_sequential)
         values["priority"] = conf.get("priority", self.priority)
         return values  # ignore: typing[no-any-return]

--- a/tests/test_dag_config.py
+++ b/tests/test_dag_config.py
@@ -78,3 +78,15 @@ def test_conf_dag_via_tag() -> None:
     d.config_from_dict(tag_cfg)
     assert d.max_concurrency == 3
     assert d.get_node_by_id("a").priority == 256
+
+
+def test_with_twz_active() -> None:
+    @dag
+    def my_dag() -> str:
+        var_a = a(1234, twz_active=True)  # type: ignore[call-arg]
+        return b(var_a, "poulpe")
+
+    my_dag.config_from_dict(
+        {"nodes": {"a": {"priority": 42, "is_sequential": False}}, "max_concurrency": 3}
+    )
+    assert my_dag() == "1234poulpe"


### PR DESCRIPTION
# Description

Fix small bug when configuring the DAG from a dict with the usage of activation

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
