### PR TITLE
fix: :bug: typing with py310 Union |

### DIFF
--- a/tawazi/node/helpers.py
+++ b/tawazi/node/helpers.py
@@ -22,6 +22,8 @@ def _validate_tuple(func: Callable[..., Any], unpack_to: int) -> Optional[bool]:
     if isinstance(r_type, str):
         # eval is safe to use because the user is providing the typing and evaluating it locally
         r_type = eval(r_type, func.__globals__)  # noqa: PGH001,S307 # nosec B307
+    if not hasattr(r_type, "__origin__"):
+        return None
     is_tuple = r_type.__origin__ is tuple
     if not is_tuple:
         return None

--- a/tests/test_multiple_return_value_for_exec_node.py
+++ b/tests/test_multiple_return_value_for_exec_node.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Dict, List, Tuple
 
 import pytest
@@ -219,3 +220,35 @@ def test_mrv_unpack_to_with_list_type() -> None:
         return r1, r2, r3, list_v
 
     assert pipe() == (1, 2, 3, [1, 2, 3])
+
+
+# if python version is 3.10 or higher, include this function
+if sys.version_info >= (3, 10):
+    from typing import Union
+
+    from tawazi import xn
+
+    union_type = Union[tuple[float, int], tuple[float, float]]
+    py311_union_type = tuple[float, int] | tuple[float, float]
+
+    @xn(unpack_to=2)
+    def union_py39(x: float, integer: bool = False) -> union_type:
+        return x, x / 2 if not integer else int(x / 2)
+
+    @dag
+    def dag_union_py39(x):
+        return union_py39(x)
+
+    def test_unpacking_union() -> None:
+        assert 1, 1 / 2 == dag_union_py39(1)
+
+    @xn(unpack_to=2)
+    def union_py310(x: float, integer: bool = False) -> py311_union_type:
+        return x, x / 2 if not integer else int(x / 2)
+
+    @dag
+    def dag_union_py310(x):
+        return union_py310(x)
+
+    def test_unpacking_union_py310() -> None:
+        assert 2, 1 == dag_union_py310(2)


### PR DESCRIPTION
# Description

Fixes issue when ExecNode's return type has `|`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
