### PR TITLE
chg: :wrench: remove loguru and raise original error in node instead of Tawazi error

### DIFF
--- a/.github/workflows/formatting-workflow.yml
+++ b/.github/workflows/formatting-workflow.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Install pre-commit
         run: |

--- a/.github/workflows/testing-workflow.yml
+++ b/.github/workflows/testing-workflow.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python_version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,6 @@ repos:
         args: []
         additional_dependencies:
           - pydantic
-          - loguru # to be removed when loguru is removed
           - pytest
           - numpy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Changes
+
+* :recycle: drop loguru to be more generic and let the end application manage the logs
+* :recycle: remove Tawazi error wrapping in node and raise original error
+* :boom: remove python 3.7 and 3.8
+
 ## v0.5.2 (2024-11-12)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tawazi
 <!--Python badges -->
-[![Python 3.7](https://img.shields.io/badge/python-3.7%20|%203.8%20|%203.9%20|%203.10%20|%203.11%20|%203.12|%203.13-blue.svg)](https://www.python.org/)
+[![Python 3.9](https://img.shields.io/badge/python-3.9%20|%203.10%20|%203.11%20|%203.12|%203.13-blue.svg)](https://www.python.org/)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![CodeFactor](https://www.codefactor.io/repository/github/mindee/tawazi/badge)](https://www.codefactor.io/repository/github/mindee/tawazi)
 [![Downloads](https://img.shields.io/pypi/dm/tawazi)](https://pypi.org/project/tawazi/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ maintainers = [
 ]
 license = {file = "LICENSE" }
 readme = "README.md"
-requires-python=">=3.7,<4"
+requires-python=">=3.9,<4"
 dependencies = [
     "networkx>=2,<4",
     "pydantic",
@@ -50,7 +50,7 @@ pydantic1 = ["pydantic>=1.0.0,<2"]
 addopts = "--pdbcls=IPython.terminal.debugger:TerminalPdb --cov-report=term-missing:skip-covered  --cov-report=lcov:cov.info --junit-xml=pytest-junit.xml --cov=tawazi"
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.9"
 # --strict
 disallow_any_generics = true
 disallow_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ requires-python=">=3.7,<4"
 dependencies = [
     "networkx>=2,<4",
     "pydantic",
-    "loguru",
     "PyYaml>=6",
     "typing_extensions>=4.4.0"
 ]

--- a/tawazi/_dag/dag.py
+++ b/tawazi/_dag/dag.py
@@ -1,5 +1,6 @@
 """module containing DAG and DAGExecution which are the containers that run ExecNodes in Tawazi."""
 import json
+import logging
 import pickle
 import warnings
 from collections import Counter
@@ -7,36 +8,27 @@ from copy import deepcopy
 from dataclasses import asdict, dataclass, field
 from itertools import chain
 from pathlib import Path
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Generic,
-    Iterable,
-    List,
-    NoReturn,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Union,
-)
+from typing import (Any, Callable, Dict, Generic, Iterable, List, NoReturn,
+                    Optional, Sequence, Set, Tuple, Union)
 
 import networkx as nx
 import yaml
-from loguru import logger
 
 from tawazi import consts
 from tawazi._helpers import StrictDict, UniqueKeyLoader
 from tawazi.config import cfg
 from tawazi.consts import ARG_NAME_ACTIVATE, RVDAG, Identifier, P, Tag
 from tawazi.errors import TawaziTypeError, TawaziUsageError
-from tawazi.node import Alias, ArgExecNode, ExecNode, ReturnUXNsType, UsageExecNode, node
+from tawazi.node import (Alias, ArgExecNode, ExecNode, ReturnUXNsType,
+                         UsageExecNode, node)
 from tawazi.node.node import LazyExecNode, make_active, make_axn_id
 from tawazi.profile import Profile
 
 from .digraph import DiGraphEx
-from .helpers import async_execute, extend_results_with_args, get_return_values, sync_execute
+from .helpers import (async_execute, extend_results_with_args,
+                      get_return_values, sync_execute)
+
+logger = logging.getLogger(__name__)
 
 
 def construct_subdag_arg_uxns(
@@ -691,7 +683,7 @@ class DAG(BaseDAG[P, RVDAG]):
                 )
 
         if description_context:
-            logger.warning("Describing SubDAG {} in DAG", self)
+            logger.debug("Describing SubDAG {} in DAG", self)
 
             # NOTE: can't call the base describing function because composed DAGs can't be supported in that case
             #  so must modify ExecNodes of SubDAG

--- a/tawazi/_dag/dag.py
+++ b/tawazi/_dag/dag.py
@@ -8,8 +8,20 @@ from copy import deepcopy
 from dataclasses import asdict, dataclass, field
 from itertools import chain
 from pathlib import Path
-from typing import (Any, Callable, Dict, Generic, Iterable, List, NoReturn,
-                    Optional, Sequence, Set, Tuple, Union)
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Generic,
+    Iterable,
+    List,
+    NoReturn,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 import networkx as nx
 import yaml
@@ -19,14 +31,12 @@ from tawazi._helpers import StrictDict, UniqueKeyLoader
 from tawazi.config import cfg
 from tawazi.consts import ARG_NAME_ACTIVATE, RVDAG, Identifier, P, Tag
 from tawazi.errors import TawaziTypeError, TawaziUsageError
-from tawazi.node import (Alias, ArgExecNode, ExecNode, ReturnUXNsType,
-                         UsageExecNode, node)
+from tawazi.node import Alias, ArgExecNode, ExecNode, ReturnUXNsType, UsageExecNode, node
 from tawazi.node.node import LazyExecNode, make_active, make_axn_id
 from tawazi.profile import Profile
 
 from .digraph import DiGraphEx
-from .helpers import (async_execute, extend_results_with_args,
-                      get_return_values, sync_execute)
+from .helpers import async_execute, extend_results_with_args, get_return_values, sync_execute
 
 logger = logging.getLogger(__name__)
 

--- a/tawazi/_dag/helpers.py
+++ b/tawazi/_dag/helpers.py
@@ -1,11 +1,11 @@
 import asyncio
 import contextvars
 import functools
-from concurrent.futures import ALL_COMPLETED, FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+import logging
+from concurrent.futures import (ALL_COMPLETED, FIRST_COMPLETED, Future,
+                                ThreadPoolExecutor, wait)
 from copy import copy
 from typing import Any, Callable, Dict, List, Set, Tuple, TypeVar
-
-from loguru import logger
 
 from tawazi._dag.digraph import DiGraphEx
 from tawazi._helpers import StrictDict
@@ -14,6 +14,7 @@ from tawazi.errors import TawaziTypeError
 from tawazi.node import ExecNode, ReturnUXNsType, UsageExecNode
 from tawazi.profile import Profile
 
+logger = logging.getLogger(__name__)
 K = TypeVar("K")
 V = TypeVar("V")
 
@@ -318,7 +319,7 @@ async def async_execute(
         highest_priority_id = max(runnable_xns_ids, key=lambda id_: graph.compound_priority[id_])
         xn = exec_nodes[highest_priority_id]
 
-        logger.info("{} will run!", xn.id)
+        logger.debug("{} will run!", xn.id)
 
         # 4.2 if the current node must be run sequentially, wait for a running node to finish.
         # in that case we must prune the graph to re-check whether a new root node

--- a/tawazi/_dag/helpers.py
+++ b/tawazi/_dag/helpers.py
@@ -2,8 +2,7 @@ import asyncio
 import contextvars
 import functools
 import logging
-from concurrent.futures import (ALL_COMPLETED, FIRST_COMPLETED, Future,
-                                ThreadPoolExecutor, wait)
+from concurrent.futures import ALL_COMPLETED, FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from copy import copy
 from typing import Any, Callable, Dict, List, Set, Tuple, TypeVar
 

--- a/tawazi/_dag/helpers.py
+++ b/tawazi/_dag/helpers.py
@@ -184,7 +184,6 @@ async def wait_for_finished_nodes_async(
 async def to_thread_in_executor(
     func: Callable[..., Any],
     executor: ThreadPoolExecutor,
-    # /, # support for python3.7
     *args: Tuple[Any],
     **kwargs: Dict[str, Any],
 ) -> "asyncio.Future[Any]":

--- a/tawazi/config.py
+++ b/tawazi/config.py
@@ -5,15 +5,10 @@ from packaging.version import Version
 
 if Version(str(pydantic.VERSION)) < Version("2"):
     # pydantic v1
-    from pydantic import Field
-    from pydantic import validator as field_validator
     from pydantic.env_settings import BaseSettings
 else:
     # pydantic v2
-    from pydantic.v1 import Field  # type: ignore[assignment]
-    from pydantic.v1 import validator as field_validator  # type: ignore[assignment]
     from pydantic.v1.env_settings import BaseSettings
-
 
 from tawazi.consts import Resource, XNOutsideDAGCall
 
@@ -43,21 +38,6 @@ class Config(BaseSettings):
 
     # choose the default Resource to use to execute the ExecNodes
     TAWAZI_DEFAULT_RESOURCE: Resource = Resource.thread
-
-    # Logger settings
-    LOGURU_LEVEL: str = Field(default="PROD", env="TAWAZI_LOGGER_LEVEL")  # type: ignore[call-arg]
-    LOGURU_BACKTRACE: bool = Field(default=False, env="TAWAZI_LOGGER_BT")  # type: ignore[call-arg]
-    # Caution: to set to False if used in prod (exposes variable names)
-    LOGURU_DIAGNOSE: bool = Field(default=False, env="TAWAZI_LOGGER_DIAGNOSE")  # type: ignore[call-arg]
-
-    @field_validator("LOGURU_LEVEL")
-    def _validate_loguru_level(cls, v: str) -> str:  # noqa: N805
-        if v == "PROD":
-            from loguru import logger
-
-            logger.disable("tawazi")
-
-        return v
 
 
 cfg = Config()

--- a/tawazi/node/node.py
+++ b/tawazi/node/node.py
@@ -14,11 +14,23 @@ from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, Union
 
 from tawazi._helpers import StrictDict, make_raise_arg_error
 from tawazi.config import cfg
-from tawazi.consts import (ARG_NAME_ACTIVATE, ARG_NAME_SEP, ARG_NAME_TAG,
-                           ARG_NAME_UNPACK_TO, RESERVED_KWARGS,
-                           RETURN_NAME_SEP, RVXN, USE_SEP_END, USE_SEP_START,
-                           Identifier, P, Resource, Tag, TagOrTags,
-                           XNOutsideDAGCall)
+from tawazi.consts import (
+    ARG_NAME_ACTIVATE,
+    ARG_NAME_SEP,
+    ARG_NAME_TAG,
+    ARG_NAME_UNPACK_TO,
+    RESERVED_KWARGS,
+    RETURN_NAME_SEP,
+    RVXN,
+    USE_SEP_END,
+    USE_SEP_START,
+    Identifier,
+    P,
+    Resource,
+    Tag,
+    TagOrTags,
+    XNOutsideDAGCall,
+)
 from tawazi.errors import TawaziError, TawaziUsageError
 from tawazi.node.uxn import UsageExecNode
 from tawazi.profile import Profile
@@ -228,9 +240,11 @@ class ExecNode:
             # 2.1 write the result
             try:
                 results[self.id] = self.exec_function(*args, **kwargs)
-            except Exception as e:
+            except Exception:
                 if self.call_location:
-                    logger.warning(f"Error occurred while executing ExecNode {self.id} at {self.call_location}")
+                    logger.warning(
+                        f"Error occurred while executing ExecNode {self.id} at {self.call_location}"
+                    )
                 raise
 
         # 3. useless return value

--- a/tawazi/node/node.py
+++ b/tawazi/node/node.py
@@ -3,6 +3,7 @@
 import dataclasses
 import functools
 import inspect
+import logging
 import warnings
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -11,33 +12,20 @@ from threading import Lock
 from types import MethodType
 from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, Union
 
-from loguru import logger
-
 from tawazi._helpers import StrictDict, make_raise_arg_error
 from tawazi.config import cfg
-from tawazi.consts import (
-    ARG_NAME_ACTIVATE,
-    ARG_NAME_SEP,
-    ARG_NAME_TAG,
-    ARG_NAME_UNPACK_TO,
-    RESERVED_KWARGS,
-    RETURN_NAME_SEP,
-    RVXN,
-    USE_SEP_END,
-    USE_SEP_START,
-    Identifier,
-    P,
-    Resource,
-    Tag,
-    TagOrTags,
-    XNOutsideDAGCall,
-)
+from tawazi.consts import (ARG_NAME_ACTIVATE, ARG_NAME_SEP, ARG_NAME_TAG,
+                           ARG_NAME_UNPACK_TO, RESERVED_KWARGS,
+                           RETURN_NAME_SEP, RVXN, USE_SEP_END, USE_SEP_START,
+                           Identifier, P, Resource, Tag, TagOrTags,
+                           XNOutsideDAGCall)
 from tawazi.errors import TawaziError, TawaziUsageError
 from tawazi.node.uxn import UsageExecNode
 from tawazi.profile import Profile
 
 from .helpers import _lazy_xn_id, _validate_tuple, make_suffix
 
+logger = logging.getLogger(__name__)
 # a temporary variable used to pass in exec_nodes to the DAG during building
 exec_nodes: StrictDict[Identifier, "ExecNode"] = StrictDict()
 # a temporary variable to hold default values concerning the DAG's description
@@ -242,11 +230,8 @@ class ExecNode:
                 results[self.id] = self.exec_function(*args, **kwargs)
             except Exception as e:
                 if self.call_location:
-                    raise TawaziError(
-                        f"Error occurred while executing ExecNode {self.id} at {self.call_location}"
-                    ) from e
-
-                raise e
+                    logger.warning(f"Error occurred while executing ExecNode {self.id} at {self.call_location}")
+                raise
 
         # 3. useless return value
         logger.debug("Finished executing {} with task {}", self.id, self.exec_function)

--- a/tests/test_error_location.py
+++ b/tests/test_error_location.py
@@ -1,9 +1,7 @@
-import inspect
 from typing import Any
 
 import pytest
 from tawazi import dag, xn
-from tawazi.errors import TawaziError
 
 
 @xn
@@ -20,14 +18,7 @@ dag_pipe = dag(pipe)
 
 
 def test_raise_error_location() -> None:
-    # path and line no of function pipe
-    pipe_path = inspect.getsourcefile(pipe)
-    pipe_lineno = inspect.getsourcelines(pipe)[1]
-
-    with pytest.raises(
-        TawaziError,
-        match=f"Error occurred while executing ExecNode faulty_function at {pipe_path}:{pipe_lineno + 1}",
-    ):
+    with pytest.raises(ValueError):
         dag_pipe()
 
 

--- a/tests/test_error_location.py
+++ b/tests/test_error_location.py
@@ -1,3 +1,5 @@
+import inspect
+import logging
 from typing import Any
 
 import pytest
@@ -17,9 +19,19 @@ def pipe() -> int:
 dag_pipe = dag(pipe)
 
 
-def test_raise_error_location() -> None:
+def test_raise_error_location(caplog: Any) -> None:
+    # path and line no of function pipe
+    pipe_path = inspect.getsourcefile(pipe)
+    pipe_lineno = inspect.getsourcelines(pipe)[1]
     with pytest.raises(ValueError):
         dag_pipe()
+    assert caplog.record_tuples == [
+        (
+            "tawazi.node.node",
+            logging.WARNING,
+            f"Error occurred while executing ExecNode faulty_function at {pipe_path}:{pipe_lineno + 1}",
+        )
+    ]
 
 
 class NoneReturner:


### PR DESCRIPTION
# Description

- Remove loguru to be more generic and let the end application manage the logs 
- Remove Tawazi error wrapping in node and raise original error (keep a log with node information)
- Remove python 3.7 and 3.8 as they reach eol 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
