### PR TITLE
Forward Context from parent to threads in tawazi

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -15,18 +15,18 @@ repos:
       - id: mixed-line-ending
 
   - repo: https://github.com/psf/black
-    rev: 23.12.1
+    rev: 25.1.0
     hooks:
     - id: black
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.1.12"
+    rev: "v0.9.9"
     hooks:
     - id: ruff
       args: ["--fix"]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.0
+    rev: v1.15.0
     hooks:
       - id: mypy
         # files:
@@ -37,7 +37,7 @@ repos:
           - numpy
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.6
+    rev: 1.8.3
     hooks:
       - id: bandit
         args: ["--ini", ".bandit", "--recursive"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changes
 
-* :recycle: factor subdag creation in a separate function
+* :recycle: refactor subdag creation in a separate function
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## v0.6.1 (2025-03-03)
+
+### Changes
+
+* :recycle: factor subdag creation in a separate function
+
+### Bug Fixes
+
+* :bug: forward context from main thread to the thread pool
+* :bug: make subdag work with constant returned values
+
 ## v0.6.0 (2025-02-25)
 
 ### Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "tawazi"
-version = "0.6.0"
+version = "0.6.1"
 description = "This library helps you execute a set of functions in a Directed Acyclic Graph (DAG) dependency structure in parallel in a production environment."
 authors = [{name = "Mindee", email = "contact@mindee.com"}]
 maintainers = [

--- a/tawazi/__init__.py
+++ b/tawazi/__init__.py
@@ -7,7 +7,7 @@ from ._object_helpers import and_, not_, or_
 from .config import cfg
 from .consts import Resource
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 __all__ = [
     "AsyncDAG",

--- a/tawazi/_dag/constructor.py
+++ b/tawazi/_dag/constructor.py
@@ -64,7 +64,7 @@ def make_dag(
     # NOTE: Only ordered parameters are supported at the moment!
     #  No **kwargs!! Only positional Arguments
     # used to be fetch the results at the end of the computation
-    returned_val: Any = _func(*uxn_args)  # type: ignore[arg-type]
+    returned_val: Any = _func(*uxn_args)  # type: ignore[call-arg]
 
     returned_usage_exec_nodes: ReturnUXNsType = wrap_in_uxns(_func, returned_val)
 

--- a/tawazi/_dag/constructor.py
+++ b/tawazi/_dag/constructor.py
@@ -64,7 +64,7 @@ def make_dag(
     # NOTE: Only ordered parameters are supported at the moment!
     #  No **kwargs!! Only positional Arguments
     # used to be fetch the results at the end of the computation
-    returned_val: Any = _func(*uxn_args)  # type: ignore[call-arg]
+    returned_val: Any = _func(*uxn_args)  # type: ignore[call-arg,arg-type]
 
     returned_usage_exec_nodes: ReturnUXNsType = wrap_in_uxns(_func, returned_val)
 

--- a/tawazi/_dag/dag.py
+++ b/tawazi/_dag/dag.py
@@ -1,4 +1,5 @@
 """module containing DAG and DAGExecution which are the containers that run ExecNodes in Tawazi."""
+
 import json
 import logging
 import pickle
@@ -263,7 +264,7 @@ class BaseDAG(Generic[P, RVDAG]):
         # the input's ID which is not a stable Alias yet
 
         def _alias_or_aliases_to_ids(
-            alias_or_aliases: Union[Alias, Sequence[Alias]]
+            alias_or_aliases: Union[Alias, Sequence[Alias]],
         ) -> list[Identifier]:
             if isinstance(alias_or_aliases, str) or isinstance(alias_or_aliases, ExecNode):
                 return [self._get_single_xn_by_alias(alias_or_aliases).id]
@@ -282,7 +283,7 @@ class BaseDAG(Generic[P, RVDAG]):
             )
 
         def _alias_or_aliases_to_uxns(
-            alias_or_aliases: Union[Alias, Sequence[Alias]]
+            alias_or_aliases: Union[Alias, Sequence[Alias]],
         ) -> ReturnUXNsType:
             if isinstance(alias_or_aliases, str) or isinstance(alias_or_aliases, ExecNode):
                 return UsageExecNode(self._get_single_xn_by_alias(alias_or_aliases).id)
@@ -618,7 +619,7 @@ class DAG(BaseDAG[P, RVDAG]):
         )
 
     # TODO: discuss whether we want to expose it or not
-    def run_subgraph(
+    def run_subgraph(  # type: ignore[valid-type]
         self, subgraph: DiGraphEx, results: Optional[StrictDict[Identifier, Any]], *args: P.args
     ) -> tuple[
         StrictDict[Identifier, ExecNode],
@@ -862,7 +863,7 @@ class AsyncDAG(BaseDAG[P, RVDAG]):
         return
 
     # TODO: refactor this with previous method
-    async def run_subgraph(
+    async def run_subgraph(  # type: ignore[valid-type]
         self, subgraph: DiGraphEx, results: Optional[StrictDict[Identifier, Any]], *args: P.args
     ) -> tuple[
         StrictDict[Identifier, ExecNode],

--- a/tawazi/_dag/dag.py
+++ b/tawazi/_dag/dag.py
@@ -688,9 +688,6 @@ class DAG(BaseDAG[P, RVDAG]):
                 exec_function=lambda x: x,
                 resource=consts.Resource.main_thread,
                 args=[axn],
-                # during subdag construction,
-                # there are only three frames to get to the actual call site
-                call_location_frame=2,  # TODO: should be three not two!!
             )
             # register this LazyExecNode in the dict
             # pass kwargs to pass in the twz_active!

--- a/tawazi/_dag/digraph.py
+++ b/tawazi/_dag/digraph.py
@@ -1,4 +1,5 @@
 """Module containing the definition of a Directed Graph Extension of networkx.DiGraph."""
+
 from collections import defaultdict
 from collections.abc import Iterable, Sequence
 from copy import deepcopy

--- a/tawazi/_dag/helpers.py
+++ b/tawazi/_dag/helpers.py
@@ -187,7 +187,7 @@ Param = ParamSpec("Param")
 R = TypeVar("R")
 
 
-def context_kept(
+def preserve_context(
     func: Callable[Param, R], *args: Param.args, **kwargs: Param.kwargs
 ) -> Callable[..., R]:
     """Wrap a function to keep the context of parent."""
@@ -361,14 +361,14 @@ async def async_execute(
         # 5.2 submit the exec node to the executor
         if xn.resource == Resource.thread:
             exec_future_sync = executor.submit(
-                context_kept(xn.execute, results=results, profiles=profiles)
+                preserve_context(xn.execute, results=results, profiles=profiles)
             )
             conc_running.add(exec_future_sync)
             conc_futures[xn.id] = exec_future_sync
         elif xn.resource == Resource.async_thread:
             exec_future_async = asyncio.ensure_future(
                 to_thread_in_executor(
-                    context_kept(xn.execute, results=results, profiles=profiles), executor
+                    preserve_context(xn.execute, results=results, profiles=profiles), executor
                 )
             )
             logger.debug("Submitted ExecNode {} to the ThreadPool in async mode", xn.id)

--- a/tawazi/_decorators.py
+++ b/tawazi/_decorators.py
@@ -2,6 +2,7 @@
 
 The user should use the decorators `@dag` and `@xn` to create Tawazi objects `DAG` and `ExecNode`.
 """
+
 import functools
 from typing import Any, Callable, Optional, Union, overload
 
@@ -16,8 +17,7 @@ from .node import LazyExecNode
 
 
 @overload
-def xn(func: Callable[P, RVXN]) -> LazyExecNode[P, RVXN]:
-    ...
+def xn(func: Callable[P, RVXN]) -> LazyExecNode[P, RVXN]: ...
 
 
 @overload
@@ -31,8 +31,7 @@ def xn(
     setup: bool = False,
     unpack_to: Optional[int] = None,
     resource: Resource = cfg.TAWAZI_DEFAULT_RESOURCE,
-) -> LazyExecNode[P, RVXN]:
-    ...
+) -> LazyExecNode[P, RVXN]: ...
 
 
 @overload
@@ -45,8 +44,7 @@ def xn(
     setup: bool = False,
     unpack_to: Optional[int] = None,
     resource: Resource = cfg.TAWAZI_DEFAULT_RESOURCE,
-) -> Callable[[Callable[P, RVXN]], LazyExecNode[P, RVXN]]:
-    ...
+) -> Callable[[Callable[P, RVXN]], LazyExecNode[P, RVXN]]: ...
 
 
 def xn(
@@ -121,8 +119,7 @@ def xn(
 
 
 @overload
-def dag(declare_dag_function: Callable[P, RVDAG]) -> DAG[P, RVDAG]:
-    ...
+def dag(declare_dag_function: Callable[P, RVDAG]) -> DAG[P, RVDAG]: ...
 
 
 @overload
@@ -131,8 +128,7 @@ def dag(
     *,
     max_concurrency: int = 1,
     is_async: Literal[False] = False,
-) -> DAG[P, RVDAG]:
-    ...
+) -> DAG[P, RVDAG]: ...
 
 
 @overload
@@ -141,29 +137,25 @@ def dag(
     *,
     max_concurrency: int = 1,
     is_async: Literal[True] = True,
-) -> AsyncDAG[P, RVDAG]:
-    ...
+) -> AsyncDAG[P, RVDAG]: ...
 
 
 @overload
 def dag(
     declare_dag_function: Callable[P, RVDAG], *, max_concurrency: int = 1, is_async: bool = False
-) -> Union[DAG[P, RVDAG], AsyncDAG[P, RVDAG]]:
-    ...
+) -> Union[DAG[P, RVDAG], AsyncDAG[P, RVDAG]]: ...
 
 
 @overload
 def dag(
     *, max_concurrency: int = 1, is_async: Literal[False] = False
-) -> Callable[[Callable[P, RVDAG]], DAG[P, RVDAG]]:
-    ...
+) -> Callable[[Callable[P, RVDAG]], DAG[P, RVDAG]]: ...
 
 
 @overload
 def dag(
     *, max_concurrency: int = 1, is_async: Literal[True] = True
-) -> Callable[[Callable[P, RVDAG]], AsyncDAG[P, RVDAG]]:
-    ...
+) -> Callable[[Callable[P, RVDAG]], AsyncDAG[P, RVDAG]]: ...
 
 
 @overload
@@ -172,8 +164,7 @@ def dag(
 ) -> Union[
     Callable[[Callable[P, RVDAG]], DAG[P, RVDAG]],
     Callable[[Callable[P, RVDAG]], AsyncDAG[P, RVDAG]],
-]:
-    ...
+]: ...
 
 
 def dag(

--- a/tawazi/consts.py
+++ b/tawazi/consts.py
@@ -1,4 +1,5 @@
 """Module containing constants used by Tawazi."""
+
 from enum import Enum, unique
 from typing import Any, TypeVar, Union
 
@@ -132,11 +133,11 @@ class Resource(str, Enum):
     """
 
     # supported behavior following a raised error
-    main_thread: str = "main-thread"
-    thread: str = "thread"
-    async_thread: str = "async-thread"
-    # process: str = "process"  # Reserved for the future
-    # sub_interpreter: str = "sub-interpreter"  # Reserved for the future
+    main_thread = "main-thread"
+    thread = "thread"
+    async_thread = "async-thread"
+    # process = "process"  # Reserved for the future
+    # sub_interpreter = "sub-interpreter"  # Reserved for the future
 
 
 # ImmutableType = Union[str, int, float, bool, Tuple[ImmutableType]]  # doesn't work because of cyclic typing
@@ -146,6 +147,6 @@ class Resource(str, Enum):
 class XNOutsideDAGCall(str, Enum):
     """The strategy to use when an ExecNode is called outside a DAG."""
 
-    warning: str = "warning"  # raise a warning a single time
-    error: str = "error"  # raise an error and stop DAG description
-    ignore: str = "ignore"  # do nothing
+    warning = "warning"  # raise a warning a single time
+    error = "error"  # raise an error and stop DAG description
+    ignore = "ignore"  # do nothing

--- a/tawazi/node/__init__.py
+++ b/tawazi/node/__init__.py
@@ -1,4 +1,5 @@
 """Node related Classes and functions."""
+
 # import extend to execute its code
 from . import extend  # noqa: F401
 from .functions import ReturnUXNsType, wrap_in_uxns

--- a/tawazi/node/extend.py
+++ b/tawazi/node/extend.py
@@ -1,4 +1,5 @@
 """Module to implement built-in operators on UsageExecNode."""
+
 from typing import Any, Callable
 
 from tawazi.config import cfg

--- a/tawazi/node/functions.py
+++ b/tawazi/node/functions.py
@@ -18,7 +18,7 @@ def _wrap_in_iterator_helper(
     l_uxn: list[UsageExecNode] = []
     for i, v in enumerate(r_val):
         if not isinstance(v, UsageExecNode):
-            xn = ReturnExecNode(func, i)
+            xn = ReturnExecNode.from_function(func, i)
             uxn = UsageExecNode(xn.id)
             l_uxn.append(uxn)
 
@@ -47,7 +47,7 @@ def _wrap_in_dict(func: Callable[..., Any], r_val: Any) -> Optional[dict[str, Us
     d_uxn: dict[str, UsageExecNode] = {}
     for k, v in r_val.items():
         if not isinstance(v, UsageExecNode):
-            xn = ReturnExecNode(func, k)
+            xn = ReturnExecNode.from_function(func, k)
             uxn = UsageExecNode(xn.id)
             d_uxn[k] = uxn
 
@@ -60,7 +60,7 @@ def _wrap_in_dict(func: Callable[..., Any], r_val: Any) -> Optional[dict[str, Us
 
 def _wrap_in_uxn(func: Callable[..., Any], r_val: Any) -> UsageExecNode:
     if not isinstance(r_val, UsageExecNode):
-        xn = ReturnExecNode(func, 0)
+        xn = ReturnExecNode.from_function(func, 0)
         node.exec_nodes[xn.id] = xn
         node.results[xn.id] = r_val
         return UsageExecNode(xn.id)

--- a/tawazi/node/helpers.py
+++ b/tawazi/node/helpers.py
@@ -1,4 +1,5 @@
 """Helpers for node subpackage."""
+
 from typing import Any, Callable, Optional, Union
 
 from tawazi._helpers import ordinal

--- a/tawazi/node/node.py
+++ b/tawazi/node/node.py
@@ -280,8 +280,11 @@ class ExecNode:
 class ReturnExecNode(ExecNode):
     """ExecNode corresponding to a constant Return value of a DAG."""
 
-    def __init__(self, func: Callable[..., Any], name_or_order: Union[str, int]):
-        """Constructor of ArgExecNode.
+    @classmethod
+    def from_function(
+        cls, func: Callable[..., Any], name_or_order: Union[str, int]
+    ) -> "ReturnExecNode":
+        """Maker of ArgExecNode.
 
         Args:
             func (Callable[..., Any]): The function (DAG describer) that this return is reattached to
@@ -295,7 +298,7 @@ class ReturnExecNode(ExecNode):
             TypeError: if type parameter is passed (Internal)
         """
         suffix = make_suffix(name_or_order)
-        super().__init__(
+        return ReturnExecNode(
             id_=f"{func}{RETURN_NAME_SEP}{suffix}",
             is_sequential=False,
             resource=Resource.main_thread,

--- a/tawazi/node/node.py
+++ b/tawazi/node/node.py
@@ -476,7 +476,7 @@ def make_default_value_uxn(
     return UsageExecNode(xn.id)
 
 
-def make_args(id_: Identifier, *args: P.args, **kwargs: P.kwargs) -> list[UsageExecNode]:
+def make_args(id_: Identifier, *args: P.args, **kwargs: P.kwargs) -> list[UsageExecNode]:  # type: ignore[valid-type]
     """Constructs the positional arguments for an ExecNode."""
     xn_args = []
 
@@ -495,7 +495,7 @@ def make_args(id_: Identifier, *args: P.args, **kwargs: P.kwargs) -> list[UsageE
 
 
 def make_kwargs(
-    id_: Identifier, *args: P.args, **kwargs: P.kwargs
+    id_: Identifier, *args: P.args, **kwargs: P.kwargs  # type: ignore[valid-type]
 ) -> dict[Identifier, UsageExecNode]:
     """Constructs the keyword arguments for an ExecNode."""
     xn_kwargs = {}
@@ -514,7 +514,7 @@ def make_kwargs(
     return xn_kwargs
 
 
-def make_active(id_: Identifier, *args: P.args, **kwargs: P.kwargs) -> Optional[UsageExecNode]:
+def make_active(id_: Identifier, *args: P.args, **kwargs: P.kwargs) -> Optional[UsageExecNode]:  # type: ignore[valid-type]
     """Constructs the active argument for an ExecNode."""
     if ARG_NAME_ACTIVATE not in kwargs:
         return None

--- a/tawazi/profile.py
+++ b/tawazi/profile.py
@@ -1,4 +1,5 @@
 """Module helper to profile execution time of Tawazi ExecNodes."""
+
 from time import perf_counter, process_time, thread_time
 from typing import Any
 

--- a/tests/test_edge_cases_dag.py
+++ b/tests/test_edge_cases_dag.py
@@ -1,11 +1,12 @@
 import asyncio
 import os
+from contextvars import ContextVar
 from functools import partial
 from typing import Any
 
 import pytest
 from networkx import NetworkXUnfeasible
-from tawazi import DAG, dag, xn
+from tawazi import DAG, Resource, dag, xn
 from tawazi._dag.digraph import DiGraphEx
 from tawazi._dag.helpers import sync_execute
 from tawazi._helpers import StrictDict
@@ -84,8 +85,7 @@ def test_setup_debug_nodes() -> None:
     with pytest.raises(ValueError):
 
         @xn(debug=True, setup=True)
-        def a() -> None:
-            ...
+        def a() -> None: ...
 
 
 def test_circular_deps() -> None:
@@ -146,3 +146,21 @@ def test_kwargs_passed_to_dag(is_async: bool) -> None:
             asyncio.run(my_dag(c="twinkle toes"))  # type: ignore[arg-type]
         else:
             my_dag(c="twinkle toes")
+
+
+ctx_var: ContextVar[str] = ContextVar("ctx_var", default="twinkle")
+
+
+@pytest.mark.parametrize("resource", [Resource.main_thread, Resource.thread, Resource.async_thread])
+def test_context(resource: Resource) -> None:
+    ctx_var.set("toes")
+
+    @xn(resource=resource)
+    def validate_context() -> None:
+        assert ctx_var.get() == "toes"
+
+    @dag
+    def validate_context_dag() -> None:
+        validate_context()
+
+    validate_context_dag()

--- a/tests/test_error_location.py
+++ b/tests/test_error_location.py
@@ -15,7 +15,7 @@ def pipe() -> int:
     return faulty_function()
 
 
-# declare dag separatly from pipe function in order to use inspect correctly
+# declare dag separately from pipe function in order to use inspect correctly
 dag_pipe = dag(pipe)
 
 

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -4,6 +4,7 @@ import pytest
 from tawazi import DAG, dag, xn
 from tawazi._dag.digraph import DiGraphEx
 from tawazi._dag.helpers import sync_execute
+from tawazi.errors import TawaziArgumentError
 
 subgraph_comp_str = ""
 T = 1e-3
@@ -134,3 +135,21 @@ def test_subgraph_return_constant() -> None:
         return subgraph()
 
     assert graph() == 1
+
+
+def sub_dag(v: Any) -> int:
+    return 1
+
+
+# declare dag separately from pipe function in order to use inspect correctly
+err_dag = dag(sub_dag)
+
+
+@dag
+def super_dag() -> None:
+    err_dag()  # type: ignore[call-arg]
+
+
+def test_raise_error_location() -> None:
+    with pytest.raises(TawaziArgumentError):
+        super_dag()

--- a/tests/test_subgraph.py
+++ b/tests/test_subgraph.py
@@ -122,3 +122,15 @@ def test_dag_subgraph_non_existing_nodes_ids() -> None:
 def test_no_nodes_running_in_subgraph() -> None:
     exec_ = dag_describer.executor(target_nodes=[])
     assert exec_() is None
+
+
+def test_subgraph_return_constant() -> None:
+    @dag
+    def subgraph() -> int:
+        return 1
+
+    @dag
+    def graph() -> int:
+        return subgraph()
+
+    assert graph() == 1


### PR DESCRIPTION
# Description

A couple of fixes for tawazi:

1. Return constant value from a subdag
2. Pass in context to threads created by tawazi
3. Refacto of SubDAG describing code
4. Add more tests for subdag testing

This fix is important to have logs working correctly inside of dag nodes when using custom loggers that leverage [contextvars](https://docs.python.org/3/library/contextvars.html)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
