### PR TITLE
Support ellipsis in Dag Compose Outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* :sparkles: Support ellipsis as outputs for dag composition.
+
 ## v0.6.2 (2025-03-14)
 
 * :bug: solve missing package packaging.

--- a/tawazi/_dag/digraph.py
+++ b/tawazi/_dag/digraph.py
@@ -166,19 +166,34 @@ class DiGraphEx(nx.DiGraph):
         Returns:
             the leaves reachable from that node.
         """
-        s_leaves = set(self.leaf_nodes)
-        s_reachable_leaves = self.single_node_successors(root)
+        reachable_leaves = self.single_node_successors(root)
+        leaves = []
 
-        return list(s_leaves.intersection(s_reachable_leaves))
+        for leaf in self.leaf_nodes:
+            if leaf in reachable_leaves:
+                leaves.append(leaf)
+
+        return leaves
 
     def get_multiple_reachable_leaves(self, roots: list[Identifier]) -> list[Identifier]:
-        all_reachable: set[Identifier] = set()
+        """Get all reachable leaf nodes from specified roots.
+
+        Args:
+            roots: the start nodes to consider
+
+        Returns:
+            the leaves reachable from all roots.
+        """
+        all_reachable = []
 
         for root in roots:
-            reachable_leaves = set(self.get_single_reachable_leaves(root))
-            all_reachable = all_reachable.union(reachable_leaves)
+            reachable_leaves = self.get_single_reachable_leaves(root)
 
-        return list(all_reachable)
+            for leaf in reachable_leaves:
+                if leaf not in all_reachable:
+                    all_reachable.append(leaf)
+
+        return all_reachable
 
     @property
     def debug_nodes(self) -> list[Identifier]:

--- a/tawazi/_dag/digraph.py
+++ b/tawazi/_dag/digraph.py
@@ -157,6 +157,29 @@ class DiGraphEx(nx.DiGraph):
         """
         return [node for node, degree in self.out_degree if degree == 0]
 
+    def get_single_reachable_leaves(self, root: Identifier) -> list[Identifier]:
+        """Get reachable leaf nodes from specified root.
+
+        Args:
+            root: the start node to consider
+
+        Returns:
+            the leaves reachable from that node.
+        """
+        s_leaves = set(self.leaf_nodes)
+        s_reachable_leaves = self.single_node_successors(root)
+
+        return list(s_leaves.intersection(s_reachable_leaves))
+
+    def get_multiple_reachable_leaves(self, roots: list[Identifier]) -> list[Identifier]:
+        all_reachable: set[Identifier] = set()
+
+        for root in roots:
+            reachable_leaves = set(self.get_single_reachable_leaves(root))
+            all_reachable = all_reachable.union(reachable_leaves)
+
+        return list(all_reachable)
+
     @property
     def debug_nodes(self) -> list[Identifier]:
         """Get the debug nodes.

--- a/tests/test_dag_compose.py
+++ b/tests/test_dag_compose.py
@@ -269,7 +269,7 @@ def test_kwargs_in_xn_composed() -> None:
         return x(v=1)
 
     d: DAG[..., tuple[int]] = dag_with_default_arg.compose("twinkle", [], [x])  # type: ignore[assignment]
-    assert d() == (1,)
+    assert d() == 1  # type: ignore[comparison-overlap]
 
 
 @dag
@@ -280,3 +280,8 @@ def complex_dag(a1: int, a2: int, a3: int) -> tuple[int, int, int]:
 def test_provide_ellipsis_as_input() -> None:
     composed = complex_dag.compose("twinkle", ..., ["_add<<1>>", "_sub<<1>>", "_mul<<1>>"])  # type: ignore[arg-type]
     assert composed(1, 2, 3) == (6, -4, 6)
+
+
+def test_provide_ellipsis_as_output() -> None:
+    composed = linear_pipe.compose("twinkle", c, ...)  # type: ignore[arg-type]
+    assert composed(0) == 1


### PR DESCRIPTION
# Description

This PR addresses #159 and implements support for the ellipsis as a shortcut for selecting all output nodes in dag composition.
